### PR TITLE
Stop using package {assertive} in favor of custom type checks (#149)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,13 +19,13 @@ License: CC0
 Encoding: UTF-8
 LazyData: true
 Imports:
-    assertive,
     dplyr (>= 0.7.0),
     methods,
     tibble,
     rlang (>= 0.2.0),
     ggplot2,
-    magrittr
+    magrittr,
+    glue
 Depends:
     R (>= 3.1.2)
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # infer 0.3.0.9000
 
+- Stop using package {assertive} in favor of custom type checks (#149)
 - Fixed `t_stat()` to use `...` so `var.equal` works
 
 # infer 0.3.0

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -44,8 +44,8 @@ calculate <- function(x,
                       ),
                       order = NULL,
                       ...) {
-  assertive::assert_is_tbl(x)
-  assertive::assert_is_a_string(stat)
+  check_type(x, tibble::is_tibble)
+  check_type(stat, rlang::is_string)
   check_for_numeric_stat(x, stat)
   check_for_factor_stat(x, stat, explanatory_variable(x))
   check_args_and_attr(x, explanatory_variable(x), response_variable(x), stat)

--- a/R/conf_int.R
+++ b/R/conf_int.R
@@ -49,12 +49,12 @@ check_ci_args <- function(x, level, type, point_estimate){
   
   if(!is.null(point_estimate)){
     if(!is.data.frame(point_estimate))
-      assertive::assert_is_numeric(point_estimate)
+      check_type(point_estimate, is.numeric)
     else
-      assertive::assert_is_data.frame(point_estimate)
+      check_type(point_estimate, is.data.frame)
   }
-  assertive::assert_is_data.frame(x)
-  assertive::assert_is_numeric(level)
+  check_type(x, is.data.frame)
+  check_type(level, is.numeric)
   if(level <= 0 || level >= 1){
     stop(paste("The value of `level` must be between 0 and 1", 
                   "non-inclusive."))
@@ -69,7 +69,7 @@ check_ci_args <- function(x, level, type, point_estimate){
                'for `type = "se"'))
 
   if(type == "se" && is.vector(point_estimate))
-    assertive::assert_is_numeric(point_estimate)
+    check_type(point_estimate, is.numeric)
 }
 
 

--- a/R/p_value.R
+++ b/R/p_value.R
@@ -25,7 +25,7 @@
 
 p_value <- function(x, obs_stat, direction){
   
-  assertive::assert_is_data.frame(x)
+  check_type(x, is.data.frame)
   obs_stat <- check_obs_stat(obs_stat)
   check_direction(direction)
   

--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -45,12 +45,12 @@
 rep_sample_n <- function(tbl, size, replace = FALSE, reps = 1, prob = NULL) {
   n <- nrow(tbl)
 
-  assertive::assert_is_data.frame(tbl)
-  assertive::assert_is_numeric(size)
-  assertive::assert_is_logical(replace)
-  assertive::assert_is_numeric(reps)
+  check_type(tbl, is.data.frame)
+  check_type(size, is.numeric)
+  check_type(replace, is.logical)
+  check_type(reps, is.numeric)
   if(!is.null(prob))
-    assertive::assert_is_numeric(prob)
+    check_type(prob, is.numeric)
 
   # assign non-uniform probabilities
   # there should be a better way!!

--- a/R/specify.R
+++ b/R/specify.R
@@ -23,7 +23,7 @@
 
 specify <- function(x, formula, response = NULL,
                     explanatory = NULL, success = NULL) {
-  assertive::assert_is_data.frame(x)
+  check_type(x, is.data.frame)
 
   # Convert all character and logical variables to be factor variables
   x <- dplyr::as_tibble(x) %>%

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -75,14 +75,14 @@ visualize <- function(data, bins = 15, method = "simulation",
                       endpoints_color = "mediumaquamarine",
                       ci_fill = "turquoise", ...) {
   
-  assertive::assert_is_data.frame(data)
-  assertive::assert_is_numeric(bins)
-  assertive::assert_is_character(method)
-  assertive::assert_is_character(dens_color)
-  assertive::assert_is_character(obs_stat_color)
-  assertive::assert_is_character(pvalue_fill)
+  check_type(data, is.data.frame)
+  check_type(bins, is.numeric)
+  check_type(method, is.character)
+  check_type(dens_color, is.character)
+  check_type(obs_stat_color, is.character)
+  check_type(pvalue_fill, is.character)
   if(!is.null(direction))
-    assertive::assert_is_character(direction)
+    check_type(direction, is.character)
   if(is.data.frame(endpoints) && 
      ( (nrow(endpoints) != 1) || (ncol(endpoints) != 2) ) ){
     stop(paste("Expecting `endpoints` to be a 1 x 2 data frame or 2",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,7 @@
+context("utils")
+
+test_that("get_type works", {
+  expect_equal(get_type(data.frame(x = 1)), "data.frame")
+  expect_equal(get_type(list(x = 1)), "list")
+  expect_equal(get_type(TRUE), "logical")
+})


### PR DESCRIPTION
This is a PR to close issue #149. Few notes:
- No tests seem to be newly broken. One test is failing (for `chisq_stat()` and `chisq_test` relations) but so it does in current `develop` branch (commit 9af42a7f).
- It deals purely with implementation methods without changing assertion logic. It introduces `check_type()` function for custom type checks by supplying predicate function and expected type name (not always necessary).
- A slight improvement can be made in `check_type()` by using `rlang::as_function()` to allow predicate function to be in form of anonymous "formula-function". This might be handy in case of complicated checks (for example [here](https://github.com/andrewpbray/infer/blob/ee1b621523c47303ecbd0a059f7ed1705b8cd9b0/R/conf_int.R#L51)). However, I think encapsulating predicate in separate function might be a better choice in the long run.
- Template for error message in `check_type()` is taken from [tidyverse style guide](http://style.tidyverse.org/error-messages.html#problem-statement).