### PR TITLE
Fully use glue package (#155)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Stop using package {assertive} in favor of custom type checks (#149)
 - Fixed `t_stat()` to use `...` so `var.equal` works
 - With the help of @echasnovski, fixed `var.equal = TRUE` for `specify() %>% calculate(stat = "t")`
+- Use custom functions for error, warning, message, and `paste()` handling (#155)
 
 # infer 0.3.0
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -52,10 +52,9 @@ calculate <- function(x,
   check_point_params(x, stat)
   
   if (!has_response(x))
-    stop(paste(
-      "The response variable is not set.",
-      "Make sure to `specify()` it first."
-    ))
+    stop_glue(
+      "The response variable is not set. Make sure to `specify()` it first."
+    )
   
   if (is.null(attr(x, "generate")) || !attr(x, "generate")) {
     if (is.null(attr(x, "null"))) {
@@ -72,22 +71,18 @@ calculate <- function(x,
       "slope",
       "correlation"
     ))
-      stop(
-        paste0(
-          "Theoretical distributions do not exist (or have not been ",
-          "implemented) for `stat = \"",
-          stat,
-          "\". Are you missing ",
-          "a `generate()` step?"
-        )
+      stop_glue(
+        "Theoretical distributions do not exist (or have not been ",
+        "implemented) for `stat` = \"{stat}\". Are you missing ",
+        "a `generate()` step?"
       )
     
     else if (!(stat %in% c("Chisq", "prop"))){
       # From `hypothesize()` to `calculate()`
       # Catch-all if generate was not called
-#      warning(paste("You unexpectantly went from `hypothesize()` to ",
-#              "`calculate()` skipping over `generate()`. Your current",
-#              "data frame is returned."))
+#      warning_glue("You unexpectantly went from `hypothesize()` to ",
+#                   "`calculate()` skipping over `generate()`. Your current ",
+#                   "data frame is returned.")
       return(x)
     }
   }
@@ -106,12 +101,9 @@ calculate <- function(x,
     )
   )) {
     if (!is.null(order)) {
-      warning(
-        paste(
-          "Statistic is not based on a difference;",
-          "the `order` argument",
-          "is ignored. Check `?calculate` for details."
-        )
+      warning_glue(
+        "Statistic is not based on a difference; the `order` argument ",
+        "is ignored. Check `?calculate` for details."
       )
     }
   }
@@ -121,10 +113,10 @@ calculate <- function(x,
                       x, order, ...)
   
   if ("NULL" %in% class(result))
-    stop(paste0(
+    stop_glue(
       "Your choice of `stat` is invalid for the ",
       "types of variables `specify`ed."
-    ))
+    )
 #  else
 #    class(result) <- append("infer", class(result))
   
@@ -173,19 +165,16 @@ calc_impl.prop <- function(stat, x, order, ...) {
   
   ## No longer needed with implementation of `check_point_params()`
   # if(!is.factor(x[[col]])){
-  #   stop(paste0("Calculating a ",
-  #               stat,
-  #               " here is not appropriate since the `",
-  #               col,
-  #               "` variable is not a factor."))
+  #   stop_glue(
+  #     "Calculating a {stat} here is not appropriate since the `{col}` ",
+  #     "variable is not a factor."
+  #   )
   # }
   
   if (is.null(attr(x, "success")))
-    stop(
-      paste(
-        'To calculate a proportion, the `"success"` argument',
-        'must be provided in `specify()`.'
-      )
+    stop_glue(
+      'To calculate a proportion, the `"success"` argument ',
+      'must be provided in `specify()`.'
     )
   
   success <- attr(x, "success")
@@ -256,10 +245,10 @@ calc_impl.Chisq <- function(stat, x, order, ...) {
       
     } else {
       # Straight from `specify()`
-        stop(paste("In order to calculate a Chi-Square Goodness of Fit",
-                   "statistic, hypothesized values must be given for the `p`",
-                   "parameter in the `hypothesize()` function prior to",
-                   "using `calculate()`"))
+        stop_glue("In order to calculate a Chi-Square Goodness of Fit ",
+                  "statistic, hypothesized values must be given for the `p` ",
+                  "parameter in the `hypothesize()` function prior to ",
+                  "using `calculate()`")
 
     }
     

--- a/R/conf_int.R
+++ b/R/conf_int.R
@@ -56,17 +56,16 @@ check_ci_args <- function(x, level, type, point_estimate){
   check_type(x, is.data.frame)
   check_type(level, is.numeric)
   if(level <= 0 || level >= 1){
-    stop(paste("The value of `level` must be between 0 and 1", 
-                  "non-inclusive."))
+    stop_glue("The value of `level` must be between 0 and 1 non-inclusive.")
   }
   
   if(!(type %in% c("percentile", "se"))){
-    stop(paste('The options for `type` are "percentile" or "se".'))
+    stop_glue('The options for `type` are "percentile" or "se".')
   }
 
   if(type == "se" && is.null(point_estimate))
-    stop(paste('A numeric value needs to be given for `point_estimate`',
-               'for `type = "se"'))
+    stop_glue('A numeric value needs to be given for `point_estimate` ',
+              'for `type = "se"')
 
   if(type == "se" && is.vector(point_estimate))
     check_type(point_estimate, is.numeric)

--- a/R/generate.R
+++ b/R/generate.R
@@ -23,10 +23,10 @@ generate <- function(x, reps = 1, type = attr(x, "type"), ...) {
   
   if(!is.null(auto_type)){
     if(auto_type != type)
-      stop(paste0("You have specified `type = \"",
-                    type, "\"`, but `type` is expected to be `\"",
-                    auto_type, "\"`. Please try again with appropriate ",
-                  "`type` value."))
+      stop_glue(
+        "You have specified `type = \"{type}\"`, but `type` is expected to be ",
+        "`\"{auto_type}\"`. Please try again with appropriate `type` value."
+      )
     else
       type <- auto_type
   }
@@ -35,21 +35,21 @@ generate <- function(x, reps = 1, type = attr(x, "type"), ...) {
   
   if (type == "permute" &&
       any(is.null(attr(x, "response")), is.null(attr(x, "explanatory")))) {
-    stop(paste("Please `specify()` an explanatory and a response variable",
-         "when permuting."))
+    stop_glue("Please `specify()` an explanatory and a response variable ",
+              "when permuting.")
   }
 ## Can't get to these anymore with tests
 #  if (type == "simulate" &&
 #      attr(x, "null") != "point" &&
 #      !(length(grep("p.", names(attr(x, "params")))) >= 1)) {
-#    stop("Simulation requires a `point` null hypothesis on proportions.")
+#    stop_glue("Simulation requires a `point` null hypothesis on proportions.")
 #  }
 #  if (type == "bootstrap" &&
 #        !(attr(attr(x, "params"), "names") %in% c("mu", "med", "sigma")) &&
 #        !is.null(attr(x, "null"))
 #      ) {
-#    stop(paste("Bootstrapping is inappropriate in this setting.",
-#          "Consider using `type = permute` or `type = simulate`."))
+#    stop_glue("Bootstrapping is inappropriate in this setting. ",
+#              "Consider using `type = permute` or `type = simulate`.")
 #  }
 
   if (type == "bootstrap") {
@@ -62,8 +62,8 @@ generate <- function(x, reps = 1, type = attr(x, "type"), ...) {
     return(simulate(x, reps, ...))
   }
 #  else if (!(type %in% c("bootstrap", "permute", "simulate")))
-#    stop(paste("Choose one of the available options for `type`:",
-#               '`"bootstrap"`, `"permute"`, or `"simulate"`'))
+#    stop_glue("Choose one of the available options for `type`: ",
+#              '`"bootstrap"`, `"permute"`, or `"simulate"`')
 }
 
 bootstrap <- function(x, reps = 1, ...) {

--- a/R/hypothesize.R
+++ b/R/hypothesize.R
@@ -25,13 +25,13 @@ hypothesize <- function(x, null, ...) {
   dots <- list(...)
   
   if( (null == "point") && (length(dots) == 0) ){
-    stop(paste("Provide a parameter and a value to check such as `mu = 30`",
-               "for the point hypothesis."))
+    stop_glue("Provide a parameter and a value to check such as `mu = 30` ",
+              "for the point hypothesis.")
   }
   
   if((null == "independence") && (length(dots) > 0)) {
-    warning(paste("Parameter values are not specified when testing that two",
-                  "variables are independent."))
+    warning_glue("Parameter values are not specified when testing that two ",
+                 "variables are independent.")
   }
   
   if((length(dots) > 0) && (null == "point")) {
@@ -54,8 +54,8 @@ hypothesize <- function(x, null, ...) {
   if(null == "point"){
     if(is.factor(response_variable(x))){
       if(!any(grepl("p", attr(attr(x, "params"), "names"))))
-        stop(paste('Testing one categorical variable requires `p`',
-                   'to be used as a parameter.'))
+        stop_glue('Testing one categorical variable requires `p` ',
+                  'to be used as a parameter.')
     }
   }
   
@@ -65,8 +65,8 @@ hypothesize <- function(x, null, ...) {
   # if(null == "point"){
   #   if(!is.factor(response_variable(x))
   #      & !any(grepl("mu|med|sigma", attr(attr(x, "params"), "names"))))
-  #     stop(paste('Testing one numerical variable requires one of',
-  #                '`mu`, `med`, or `sd` to be used as a parameter.'))
+  #     stop_glue('Testing one numerical variable requires one of ',
+  #               '`mu`, `med`, or `sd` to be used as a parameter.')
   # }
   
   return(as.tbl(x))

--- a/R/p_value.R
+++ b/R/p_value.R
@@ -39,9 +39,8 @@ p_value <- function(x, obs_stat, direction){
   ## Theoretical-based p-value
   # Could be more specific
   # else if(is.null(attr(x, "theory_type")) || is.null(attr(x, "distr_param")))
-  #   stop(paste("Attributes have not been set appropriately.",
-  #              "Check your {infer} pipeline again."
-  #   ))
+  #   stop_glue("Attributes have not been set appropriately. ",
+  #             "Check your {{infer}} pipeline again.")
   
   # if(!("stat" %in% names(x))){
   #    # Theoretical distribution

--- a/R/print_methods.R
+++ b/R/print_methods.R
@@ -6,16 +6,23 @@
 #' @export
 print.infer <- function(x, ...) {
   attrs <- names(attributes(x))
+  header <- character(3)
   if ("response" %in% attrs) {
-    cat(paste0("Response: ", attr(x, "response"), " (", 
-               attr(x, "response_type"), ")", "\n"))
+    header[1] <- glue_null(
+      'Response: {attr(x, "response")} ({attr(x, "response_type")})'
+    )
     if ("explanatory" %in% attrs) {
-      cat(paste0("Explanatory: ", attr(x, "explanatory"), 
-                 " (", attr(x, "explanatory_type"), ")", "\n"))
+      header[2] <- glue_null(
+        'Explanatory: {attr(x, "explanatory")} ({attr(x, "explanatory_type")})'
+      )
     }
   }
   if ("null" %in% attrs) {
-    cat(paste("Null Hypothesis: ", attr(x, "null"), "\n"))
+    header[3] <- glue_null('Null Hypothesis: {attr(x, "null")}')
   }
+  
+  cat(glue::glue_collapse(header[header != ""], sep = "\n"))
+  cat("\n")
+  
   NextMethod()
 }

--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -57,8 +57,9 @@ rep_sample_n <- function(tbl, size, replace = FALSE, reps = 1, prob = NULL) {
   # prob needs to be nrow(tbl) -- not just number of factor levels
   if (!is.null(prob)) {
     if (length(prob) != n)
-      stop(paste("The argument `prob` must have length `nrow(tbl)` = ",
-                 nrow(tbl)))
+      stop_glue(
+        "The argument `prob` must have length `nrow(tbl)` = {nrow(tbl)}"
+      )
 
     prob <- dplyr::data_frame(vals = levels(dplyr::pull(tbl, 1))) %>%
       dplyr::mutate(probs = prob) %>%

--- a/R/set_params.R
+++ b/R/set_params.R
@@ -111,7 +111,7 @@ set_params <- function(x){
   }
   
 #  if(is.null(attr(x, "theory_type")))
-#     warning("Theoretical type not yet implemented")
+#     warning_glue("Theoretical type not yet implemented")
   
   x
 }

--- a/R/specify.R
+++ b/R/specify.R
@@ -31,11 +31,11 @@ specify <- function(x, formula, response = NULL,
     mutate_if(is.logical, as.factor)
 
   if ((!methods::hasArg(formula) && !methods::hasArg(response))){
-    stop("Please give the `response` variable.")
+    stop_glue("Please give the `response` variable.")
   }
   if (methods::hasArg(formula)) {
     if (!rlang::is_formula(formula)) {
-      stop("The `formula` argument is not recognized as a formula.")
+      stop_glue("The `formula` argument is not recognized as a formula.")
     }
   }
 
@@ -48,8 +48,8 @@ specify <- function(x, formula, response = NULL,
   }
   
   if (!(as.character(attr(x, "response")) %in% names(x))) {
-    stop(paste0("The response variable `", attr(x, "response"),
-                "` cannot be found in this dataframe."))
+    stop_glue('The response variable `{attr(x, "response")}` ',
+              'cannot be found in this dataframe.')
   }
 
   response_col <- rlang::eval_tidy(attr(x, "response"), x)
@@ -57,13 +57,13 @@ specify <- function(x, formula, response = NULL,
   # if there's an explanatory var
   if(has_explanatory(x)) {
     if(!as.character(attr(x, "explanatory")) %in% names(x)) {
-      stop(paste0("The explanatory variable `", attr(x, "explanatory"),
-                  "` cannot be found in this dataframe."))
+      stop_glue('The explanatory variable `{attr(x, "explanatory")}` ',
+                'cannot be found in this dataframe.')
     }
     if(identical(as.character(attr(x, "response")),
                   as.character(attr(x, "explanatory")))) {
-      stop(paste("The response and explanatory variables must be different",
-                 "from one another."))
+      stop_glue("The response and explanatory variables must be different ",
+                "from one another.")
     }
     explanatory_col <- rlang::eval_tidy(attr(x, "explanatory"), x)
     if(is.character(explanatory_col)) {
@@ -75,19 +75,18 @@ specify <- function(x, formula, response = NULL,
 
   if (!is.null(success)) {
     if (!is.character(success)) {
-      stop("`success` must be a string.")
+      stop_glue("`success` must be a string.")
     }
     if (!is.factor(response_col)) {
-      stop(paste("`success` should only be specified if the response is",
-                 "a categorical variable."))
+      stop_glue("`success` should only be specified if the response is ",
+                "a categorical variable.")
     }
     if (!(success %in% levels(response_col))) {
-      stop(paste0(success, " is not a valid level of ",
-                  attr(x, "response"), "."))
+      stop_glue('{success} is not a valid level of {attr(x, "response")}.')
     }
     if (sum(table(response_col) > 0) > 2) {
-      stop(paste("`success` can only be used if the response has two levels.",
-           "`filter()` can reduce a variable to two levels."))
+      stop_glue("`success` can only be used if the response has two levels. ",
+                "`filter()` can reduce a variable to two levels.")
     }
   }
 
@@ -100,8 +99,7 @@ specify <- function(x, formula, response = NULL,
   is_complete <- stats::complete.cases(x)
   if (!all(is_complete)) {
     x <- dplyr::filter(x, is_complete)
-    warning(paste0("Removed ", sum(!is_complete), 
-                   " rows containing missing values."), call. = FALSE)
+    warning_glue("Removed {sum(!is_complete)} rows containing missing values.")
   }
 
   
@@ -118,10 +116,10 @@ specify <- function(x, formula, response = NULL,
      (is.null(attr(x, "explanatory_type")) ||
      (!is.null(attr(x, "explanatory_type")) &&
      length(levels(explanatory_variable(x))) == 2)) )
-    stop(paste0("A level of the response variable `",
-                attr(x, "response"),
-                "` needs to be specified for the `success` argument ",
-                "in `specify()`."))
+    stop_glue(
+      'A level of the response variable `{attr(x, "response")}` ',
+      'needs to be specified for the `success` argument in `specify()`.'
+    )
 
   # Determine appropriate parameters for theoretical distribution fit
   x <- set_params(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,32 +57,44 @@ stop_glue <- function(..., .sep = "", .envir = parent.frame(),
   )
 }
 
+warning_glue <- function(..., .sep = "", .envir = parent.frame(),
+                         call. = FALSE, .domain = NULL) {
+  warning(
+    glue::glue(..., .sep = .sep, .envir = .envir),
+    call. = call., domain = .domain
+  )
+}
+
+message_glue <- function(..., .sep = "", .envir = parent.frame(),
+                         .domain = NULL, .appendLF = TRUE) {
+  message(
+    glue::glue(..., .sep = .sep, .envir = .envir),
+    domain = .domain, appendLF = .appendLF
+  )
+}
+
 check_order <- function(x, explanatory_variable, order){
   unique_explanatory_variable <- unique(explanatory_variable)
   if (length(unique_explanatory_variable) != 2){
-    stop(paste("Statistic is based on a difference; the explanatory variable",
-               "should have two levels."))
+    stop_glue("Statistic is based on a difference; the explanatory variable ",
+              "should have two levels.")
   }
   if(is.null(order)){
-    stop(paste("Statistic is based on a difference; specify the `order` in",
-               "which to subtract the levels of the explanatory variable.",
-               '`order = c("first", "second")` means `("first" - "second")`',
-               "Check `?calculate` for details."),
-         call. = FALSE)
+    stop_glue("Statistic is based on a difference; specify the `order` in ",
+              "which to subtract the levels of the explanatory variable. ",
+              '`order = c("first", "second")` means `("first" - "second")`. ',
+              "Check `?calculate` for details.")
   } else {
     if(xor(is.na(order[1]), is.na(order[2])))
-      stop(paste("Only one level specified in `order`.",
-                 "Both levels need to be specified."),
-           call. = FALSE)
+      stop_glue(
+        "Only one level specified in `order`. Both levels need to be specified."
+      )
     if(length(order) > 2)
-      stop("`order` is expecting only two entries.",
-           call. = FALSE)
+      stop_glue("`order` is expecting only two entries.")
     if(order[1] %in% unique_explanatory_variable == FALSE)
-      stop(paste(order[1], "is not a level of the explanatory variable."),
-           call. = FALSE)
+      stop_glue("{order[1]} is not a level of the explanatory variable.")
     if(order[2] %in% unique_explanatory_variable == FALSE)
-      stop(paste(order[2], "is not a level of the explanatory variable."),
-           call. = FALSE)
+      stop_glue("{order[2]} is not a level of the explanatory variable.")
   }
 }
 
@@ -94,35 +106,29 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
   if (!stat %in% c("mean", "median", "sd", "prop",
                    "diff in means", "diff in medians", "diff in props",
                    "Chisq", "F", "slope", "correlation", "t", "z")){
-    stop(paste("You specified a string for `stat` that is not implemented.",
-               "Check your spelling and `?calculate` for current options."),
-         call. = FALSE)
+    stop_glue("You specified a string for `stat` that is not implemented. ",
+              "Check your spelling and `?calculate` for current options.")
   }
   
   if (!("replicate" %in% names(x)) && !is.null(attr(x, "generate")))
-    warning(paste0('A `generate()` step was not performed prior to',
-                   '`calculate()`. Review carefully.'),
-            call. = FALSE)
+    warning_glue('A `generate()` step was not performed prior to ',
+                 '`calculate()`. Review carefully.')
   
   if (stat %in% c("F", "slope", "diff in means", "diff in medians")){
     if (has_explanatory(x) && !is.numeric(response_variable(x))){
-      stop(paste0("The response variable of `",
-                  attr(x, "response"),
-                  "` is not appropriate \n  since '",
-                  stat,
-                  "' is expecting the response variable to be numeric."),
-           call. = FALSE)
+      stop_glue(
+        'The response variable of `{attr(x, "response")}` is not appropriate\n',
+        "since '{stat}' is expecting the response variable to be numeric."
+      )
     }
   }
   
   if (stat %in% c("diff in props", "Chisq")){
     if (has_explanatory(x) && !is.factor(response_variable(x))){
-      stop(paste0("The response variable of `",
-                  attr(x, "response"),
-                  "` is not appropriate \n  since '",
-                  stat,
-                  "' is expecting the response variable to be a factor."),
-           call. = FALSE)
+      stop_glue(
+        'The response variable of `{attr(x, "response")}` is not appropriate\n',
+        "since '{stat}' is expecting the response variable to be a factor."
+      )
     }
   }
 }
@@ -132,12 +138,10 @@ check_for_numeric_stat <- function(x, stat){
     col <- base::setdiff(names(x), "replicate")
     
     if (!is.numeric(x[[as.character(col)]])){
-      stop(paste0("Calculating a ",
-                  stat,
-                  " here is not appropriate \n since the `",
-                  col,
-                  "` variable is not numeric."),
-           call. = FALSE)
+      stop_glue(
+        "Calculating a {stat} here is not appropriate\n",
+        "since the `{col}` variable is not numeric."
+      )
     }
   }
 }
@@ -146,12 +150,11 @@ check_for_factor_stat <- function(x, stat, explanatory_variable){
   
   if (stat %in% c("diff in means", "diff in medians", "diff in props", "F")){
     if (!is.factor(explanatory_variable)){
-      stop(paste0("The explanatory variable of `",
-                  attr(x, "explanatory"),
-                  "` is not appropriate \n since '",
-                  stat,
-                  "' is expecting the explanatory variable to be a factor."),
-           call. = FALSE)
+      stop_glue(
+        'The explanatory variable of `{attr(x, "explanatory")}` is not ',
+        "appropriate\n",
+        "since '{stat}` is expecting the explanatory variable to be a factor."
+      )
     }
   }
 }
@@ -159,33 +162,26 @@ check_for_factor_stat <- function(x, stat, explanatory_variable){
 check_point_params <- function(x, stat){
   
   param_names <- attr(attr(x, "params"), "names") 
-  hyp_text <- ' to be set in `hypothesize()`.'
+  hyp_text <- 'to be set in `hypothesize()`.'
   if(!is.null(attr(x, "null"))){
     if(stat %in% c("mean", "median", "sd", "prop")){
       if( (stat == "mean" && !("mu" %in% param_names)) )
-        stop(paste0('`stat == "mean"` requires `"mu"`', hyp_text),
-             call. = FALSE)
+        stop_glue('`stat == "mean"` requires `"mu"` {hyp_text}')
       if ( (!(stat == "mean") && ("mu" %in% param_names)) )
-        stop(paste0('`"mu"` does not correspond to `stat = "', stat, '"`.'),
-             call. = FALSE)
+        stop_glue('`"mu"` does not correspond to `stat = "{stat}"`.')
       if( (stat == "median" && !("med" %in% param_names) ) )
-        stop(paste0('`stat == "median"` requires `"med"`', hyp_text),
-             call. = FALSE)
+        stop_glue('`stat == "median"` requires `"med"` {hyp_text}')
       if ( (!(stat == "median") && ("med" %in% param_names)) )
-        stop(paste0('`"med"` does not correspond to `stat = "', stat, '"`.'),
-             call. = FALSE)
+        stop_glue('`"med"` does not correspond to `stat = "{stat}"`.')
       ## Tests unable to get to
       # if( (stat == "sigma" && !("sd" %in% param_names)) )
-      #   stop(paste0('`stat == "sd"` requires `"sigma"`', hyp_text),
-      #        call. = FALSE)
+      #   stop_glue('`stat == "sd"` requires `"sigma"` {hyp_text}')
       if ( (!(stat == "sd") && ("sigma" %in% param_names)) )
-        stop(paste0('`"sigma"` does not correspond to `stat = "', stat, '"`.'),
-             call. = FALSE)
+        stop_glue('`"sigma"` does not correspond to `stat = "{stat}"`.')
       
       ## Tests unable to get to
       # if(stat == "prop" && !(any(grepl("p.", param_names))))
-      #   stop(paste0('`stat == "prop"` requires `"p"`', hyp_text),
-      #        call. = FALSE)
+      #   stop_glue('`stat == "prop"` requires `"p"` {hyp_text}')
     }
   }
 }
@@ -199,8 +195,9 @@ parse_params <- function(dots, x) {
   # error: cannot specify more than one of props, means, medians, or sds
   if ( length(p_ind) + length(mu_ind) + length(med_ind) 
        + length(sig_ind) != 1 ){
-    stop('Parameter values can be only one of `p`, `mu`, `med`, or `sigma`.',
-         call. = FALSE)
+    stop_glue(
+      'Parameter values can be only one of `p`, `mu`, `med`, or `sigma`.'
+    )
   }
   
   # add in 1 - p if it's missing
@@ -210,29 +207,28 @@ parse_params <- function(dots, x) {
     if (length(dots[[p_ind]]) == 1) {
       
       if (attr(x, "null") == "point" && is.null(attr(x, "success"))) {
-        stop(paste("A point null regarding a proportion requires",
-                   "that `success` be indicated in `specify()`."),
-             call. = FALSE)
+        stop_glue("A point null regarding a proportion requires ",
+                  "that `success` be indicated in `specify()`.")
       }
       if(dots$p < 0 || dots$p > 1)
-        stop("The value suggested for `p` is not between 0 and 1, inclusive.",
-             call. = FALSE)
+        stop_glue(
+          "The value suggested for `p` is not between 0 and 1, inclusive."
+        )
       missing_lev <- base::setdiff(unique(pull(x, !!attr(x, "response"))), 
                              attr(x, "success"))
       dots$p <- append(dots$p, 1 - dots$p)
       names(dots$p) <- c(attr(x, "success"), missing_lev)
     } else {
       if(sum(dots$p) != 1){
-        stop(paste("Make sure the hypothesized values for the `p` parameters",
-                   "sum to 1. Please try again."),
-             call. = FALSE)
+        stop_glue("Make sure the hypothesized values for the `p` parameters ",
+                  "sum to 1. Please try again.")
       }
     }
   }
   
   # if (sum(dots[[p_ind]]) != 1){
   #   dots[[p_ind]] <- dots[[p_ind]]/sum(dots[[p_ind]])
-  #   warning("Proportions do not sum to 1, normalizing automatically.")
+  #   warning_glue("Proportions do not sum to 1, normalizing automatically.")
   # }
   
   return(unlist(dots))
@@ -241,32 +237,31 @@ parse_params <- function(dots, x) {
 hypothesize_checks <- function(x, null){
   # error: x is not a dataframe
   if (!sum(class(x) %in% c("data.frame", "tbl", "tbl_df", "grouped_df"))) {
-    stop("x must be a data.frame or tibble",
-         call. = FALSE)
+    stop_glue("x must be a data.frame or tibble")
   }
   
   # error: null not found
   if (!(null %in% c("independence", "point"))) {
-    stop("Choice of null is not supported. Check `?hypothesize` for options.",
-         call. = FALSE)
+    stop_glue(
+      "Choice of null is not supported. Check `?hypothesize` for options."
+    )
   }
   
   #  if (length(null) != 1) {
-  #    stop(paste0('Choose between either `"independence"` or `"point"`',
-  #                 'for `null` argument.')
+  #    stop_glue('Choose between either `"independence"` or `"point"` ',
+  #              'for `null` argument.')
   #  }
   
   if(!has_response(x)){
-    stop(paste("The response variable is not set.",
-               "Make sure to `specify()` it first."),
-         call. = FALSE)
+    stop_glue(
+      "The response variable is not set. Make sure to `specify()` it first."
+    )
   }
   
   if(null == "independence" && !has_explanatory(x)){
-    stop(paste0('Please `specify()` an explanatory and a response variable ',
-                'when testing \n',
-                'a null hypothesis of `"independence"`.'),
-         call. = FALSE)
+    stop_glue('Please `specify()` an explanatory and a response variable ',
+              'when testing\n',
+              'a null hypothesis of `"independence"`.')
   }
 }
 
@@ -276,9 +271,9 @@ check_direction <- function(direction = c("less", "greater", "two_sided",
   
   if(!(direction %in% c("less", "greater", "two_sided",
                         "left", "right", "both"))){
-    stop(paste('The provided value for `direction` is not appropriate.',
-               'Possible values are "less", "greater", "two_sided"',
-               '"left", "right", or "both".'))
+    stop_glue('The provided value for `direction` is not appropriate. ',
+              'Possible values are "less", "greater", "two_sided", ',
+              '"left", "right", or "both".')
   }
 }
 
@@ -287,8 +282,8 @@ check_obs_stat <- function(obs_stat){
     if("data.frame" %in% class(obs_stat)){
       check_type(obs_stat, is.data.frame)
       if( (nrow(obs_stat) != 1) || (ncol(obs_stat) != 1) ) 
-        warning(paste("The first row and first column value of the given", 
-                      "`obs_stat` will be used."))
+        warning_glue("The first row and first column value of the given ", 
+                     "`obs_stat` will be used.")
       
       # [[1]] is used in case `stat` is not specified as name of 1x1
       obs_stat <- obs_stat[[1]][[1]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,7 +52,7 @@ has_response <- function(x){
 stop_glue <- function(..., .sep = "", .envir = parent.frame(),
                       call. = FALSE, .domain = NULL) {
   stop(
-    glue::glue(..., .sep = .sep, .envir = .envir),
+    glue_null(..., .sep = .sep, .envir = .envir),
     call. = call., domain = .domain
   )
 }
@@ -60,7 +60,7 @@ stop_glue <- function(..., .sep = "", .envir = parent.frame(),
 warning_glue <- function(..., .sep = "", .envir = parent.frame(),
                          call. = FALSE, .domain = NULL) {
   warning(
-    glue::glue(..., .sep = .sep, .envir = .envir),
+    glue_null(..., .sep = .sep, .envir = .envir),
     call. = call., domain = .domain
   )
 }
@@ -68,9 +68,25 @@ warning_glue <- function(..., .sep = "", .envir = parent.frame(),
 message_glue <- function(..., .sep = "", .envir = parent.frame(),
                          .domain = NULL, .appendLF = TRUE) {
   message(
-    glue::glue(..., .sep = .sep, .envir = .envir),
+    glue_null(..., .sep = .sep, .envir = .envir),
     domain = .domain, appendLF = .appendLF
   )
+}
+
+glue_null <- function(..., .sep = "", .envir = parent.frame()) {
+  glue::glue(
+    ..., .sep = .sep, .envir = .envir, .transformer = null_transformer
+  )
+}
+
+# This allows to print 'NULL' in `glue()` for code which evaluates in `NULL`
+null_transformer <- function(text, envir) {
+  out <- eval(parse(text = text, keep.source = FALSE), envir)
+  if (is.null(out)) {
+    return("NULL")
+  }
+  
+  out
 }
 
 check_order <- function(x, explanatory_variable, order){

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -85,14 +85,15 @@ visualize <- function(data, bins = 15, method = "simulation",
     check_type(direction, is.character)
   if(is.data.frame(endpoints) && 
      ( (nrow(endpoints) != 1) || (ncol(endpoints) != 2) ) ){
-    stop(paste("Expecting `endpoints` to be a 1 x 2 data frame or 2",
-                  "element vector."))
+    stop_glue(
+      "Expecting `endpoints` to be a 1 x 2 data frame or 2 element vector."
+    )
   }
   if(is.vector(endpoints) && ( length(endpoints) != 2) ) {
-    warning(paste("Expecting `endpoints` to be a 1 x 2 data frame or 2", 
-                  "element vector.",
-                  "Using the first two entries as", 
-                  "the `endpoints`."))
+    warning_glue(
+      "Expecting `endpoints` to be a 1 x 2 data frame or 2 element vector. ",
+      "Using the first two entries as the `endpoints`."
+    )
     endpoints <- endpoints[1:2]
   }
   if(is.data.frame(endpoints))
@@ -100,9 +101,10 @@ visualize <- function(data, bins = 15, method = "simulation",
   obs_stat <- check_obs_stat(obs_stat)
   if(!is.null(direction) && 
      (is.null(obs_stat) + is.null(endpoints)) != 1)
-    stop(paste("Shading requires either `endpoints` values for a", 
-               "confidence interval or the observed statistic", 
-               "`obs_stat` to be provided."))
+    stop_glue(
+      "Shading requires either `endpoints` values for a confidence interval ",
+      "or the observed statistic `obs_stat` to be provided."
+    )
 
   if(method == "simulation"){
     
@@ -132,14 +134,15 @@ visualize <- function(data, bins = 15, method = "simulation",
   } else if(method == "both"){
     
     if(!("stat" %in% names(data)))
-      stop(paste0('`generate()` and `calculate()` are both required ', 
-                  'to be done prior to `visualize(method = "both")`'))
+      stop_glue('`generate()` and `calculate()` are both required ',
+                'to be done prior to `visualize(method = "both")`')
     
     if(("replicate" %in% names(data)) &&
          length(unique(data$replicate)) < 100)
-      warning(paste("With only", length(unique(data$stat)),
-                    "replicates, it may be difficult to see the",
-                    "relationship between simulation and theory."))
+      warning_glue(
+        "With only {length(unique(data$stat))} replicates, it may be ",
+        "difficult to see the relationship between simulation and theory."
+      )
     
     infer_plot <- visualize_both(data = data, bins = bins, 
                                  dens_color = dens_color,
@@ -151,10 +154,9 @@ visualize <- function(data, bins = 15, method = "simulation",
                                  ci_fill = ci_fill,
                                  ...)
   } else {
-    stop(paste("Provide `method` with one of three options:",
-               '`"theoretical"`, `"both"`, or `"simulation"`',
-               '`"simulation"` is the default.')
-    )
+    stop_glue("Provide `method` with one of three options: ",
+              '`"theoretical"`, `"both"`, or `"simulation"`. ',
+              '`"simulation"` is the default.')
   }
   
   if(!is.null(obs_stat)){#&& !is.null(direction)
@@ -164,8 +166,8 @@ visualize <- function(data, bins = 15, method = "simulation",
   
   if(!is.null(endpoints)){
     if(!is.null(obs_stat))
-      warning(paste("Values for both `endpoints` and `obs_stat` were given",
-                  "when only one should be set. Ignoring `obs_stat` values."))
+      warning_glue("Values for both `endpoints` and `obs_stat` were given ",
+                   "when only one should be set. Ignoring `obs_stat` values.")
     infer_plot <- infer_plot +
       geom_vline(xintercept = endpoints, size = 2, 
                  color = endpoints_color, 
@@ -239,8 +241,9 @@ both_anova_plot <- function(data, deg_freedom_top,
                             ....){
   
   if(!is.null(direction) && !(direction %in% c("greater", "right")))
-    warning(paste("F usually corresponds to right-tailed tests. Proceed",
-                  "with caution."), call. = FALSE)
+    warning_glue(
+      "F usually corresponds to right-tailed tests. Proceed with caution."
+    )
   
   infer_anova_plot <- shade_density_check(data = data, 
                                           obs_stat = obs_stat,
@@ -319,8 +322,8 @@ both_chisq_plot <- function(data, deg_freedom, statistic_text = "Chi-Square",
                             ...){
   
   if(!is.null(direction) && !(direction %in% c("greater", "right")))
-     warning(paste("Chi-square usually corresponds to right-tailed tests.",
-                   "Proceed with caution."), call. = FALSE)
+    warning_glue("Chi-square usually corresponds to right-tailed tests. ",
+                 "Proceed with caution.")
   
   infer_chisq_plot <- shade_density_check(data = data,
                                           obs_stat = obs_stat,
@@ -472,16 +475,17 @@ visualize_theoretical <- function(data,
                                   ci_fill, 
                                   ...) {
   
-  warning(paste("Check to make sure the conditions", 
-                "have been met for",
-                "the theoretical method. `infer` currently does not check",
-                "these for you."), call. = FALSE)
+  warning_glue(
+    "Check to make sure the conditions have been met for the theoretical ",
+    "method. {{infer}} currently does not check these for you."
+  )
   
   if(!is.null(attr(data, "stat")) && 
      !(attr(data, "stat") %in% c("t", "z", "Chisq", "F")))
-    warning(paste("Your `calculate`d statistic and the theoretical", 
-                  "distribution are on different scales. Displaying only", 
-                  "the theoretical distribution."))
+    warning_glue(
+      "Your `calculate`d statistic and the theoretical distribution are on ",
+      "different scales. Displaying only the theoretical distribution."
+    )
   
   if(attr(data, "theory_type") %in% 
      c("Two sample t", "Slope with t", "One sample t")){    
@@ -493,8 +497,9 @@ visualize_theoretical <- function(data,
   else if(attr(data, "theory_type") == "ANOVA"){
     
     if(!is.null(direction) && !(direction %in% c("greater", "right")))
-      warning(paste("F usually corresponds to right-tailed tests. Proceed",
-                    "with caution."))
+      warning_glue(
+        "F usually corresponds to right-tailed tests. Proceed with caution."
+      )
     
     infer_plot <- theory_anova_plot(
       deg_freedom_top = attr(data, "distr_param"), 
@@ -513,8 +518,8 @@ visualize_theoretical <- function(data,
           c("Chi-square test of indep", "Chi-square Goodness of Fit")){   
     
     if(!is.null(direction) && !(direction %in% c("greater", "right")))
-      warning(paste("Chi-square usually corresponds to right-tailed tests.",
-                    "Proceed with caution."))
+      warning_glue("Chi-square usually corresponds to right-tailed tests. ",
+                   "Proceed with caution.")
     
     infer_plot <- theory_chisq_plot(deg_freedom = attr(data, "distr_param"),
                                     statistic_text = "Chi-Square",
@@ -522,8 +527,9 @@ visualize_theoretical <- function(data,
   }
   
 #  else
-#    stop(paste0("'", attr(data, "theory_type"), "' is not implemented",
-#                "(possibly yet)."))
+#    stop_glue(
+#      '"{attr(data, "theory_type")}" is not implemented (possibly yet).'
+#    )
   
   # Move into its own function
   
@@ -587,14 +593,14 @@ visualize_both <- function(data, bins,
                            endpoints, 
                            ci_fill, ...) {
   
-  warning(paste("Check to make sure the conditions", 
-                "have been met for",
-                "the theoretical method. `infer` currently does not check",
-                "these for you."), call. = FALSE)
+  warning_glue(
+    "Check to make sure the conditions have been met for the theoretical ",
+    "method. `infer` currently does not check these for you."
+  )
   
   if(!(attr(data, "stat") %in% c("t", "z", "Chisq", "F")))
-    stop(paste("Your `calculate`d statistic and the theoretical distribution",
-               "are on different scales. Use a standardized `stat` instead."))
+    stop_glue("Your `calculate`d statistic and the theoretical distribution ",
+              "are on different scales. Use a standardized `stat` instead.")
   
   if(attr(data, "theory_type") %in% c("Two sample t", "Slope with t")){
     
@@ -654,7 +660,7 @@ visualize_both <- function(data, bins,
   }
   
 #  else
-#    stop(paste0("'", attr(data, "theory_type"), "' is not implemented yet."))
+#    stop_glue('"{attr(data, "theory_type")}" is not implemented yet.')
   
   infer_plot
 }

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -184,8 +184,7 @@ theory_t_plot <- function(deg_freedom, statistic_text = "t",
                           qt(0.999, deg_freedom)))) + 
     stat_function(mapping = aes(x), fun = dt, args = list(df = deg_freedom), 
                   color = dens_color) +
-    ggtitle(paste("Theoretical", statistic_text, 
-                  "Null Distribution")) +
+    ggtitle(glue_null("Theoretical {statistic_text} Null Distribution")) +
     xlab("") +
     ylab("")
 }
@@ -210,8 +209,9 @@ both_t_plot <- function(data = data, deg_freedom, statistic_text = "t",
   infer_t_plot +
     stat_function(fun = dt, args = list(df = deg_freedom), 
                   color = dens_color) +
-    ggtitle(paste("Simulation-Based and Theoretical", 
-                  statistic_text, "Null Distributions")) +
+    ggtitle(glue_null(
+      "Simulation-Based and Theoretical {statistic_text} Null Distributions"
+    )) +
     xlab("tstat") +
     ylab("")
 }
@@ -224,7 +224,7 @@ theory_anova_plot <- function(deg_freedom_top, deg_freedom_bottom,
     stat_function(mapping = aes(x), fun = df, 
                   args = list(df1 = deg_freedom_top, df2 = deg_freedom_bottom),
                   color = dens_color) +
-    ggtitle(paste("Theoretical", statistic_text, "Null Distribution")) +
+    ggtitle(glue_null("Theoretical {statistic_text} Null Distribution")) +
     xlab("") +
     ylab("")
 }
@@ -257,8 +257,9 @@ both_anova_plot <- function(data, deg_freedom_top,
     stat_function(fun = df, 
                   args = list(df1 = deg_freedom_top, df2 = deg_freedom_bottom),
                   color = dens_color) +
-    ggtitle(paste("Simulation-Based and Theoretical", 
-                  statistic_text, "Null Distributions")) +
+    ggtitle(glue_null(
+      "Simulation-Based and Theoretical {statistic_text} Null Distributions"
+    )) +
     xlab("Fstat") +
     ylab("")  
 }
@@ -267,7 +268,7 @@ theory_z_plot <- function(statistic_text = "z", dens_color = dens_color,  ...){
   
   ggplot(data.frame(x = c(qnorm(0.001), qnorm(0.999)))) + 
     stat_function(mapping = aes(x), fun = dnorm, color = dens_color) +
-    ggtitle(paste("Theoretical", statistic_text, "Null Distribution")) +
+    ggtitle(glue_null("Theoretical {statistic_text} Null Distribution")) +
     xlab("") +
     ylab("")
 }
@@ -292,8 +293,9 @@ both_z_plot <- function(data, statistic_text = "z",
   
   infer_z_plot +
     stat_function(fun = dnorm, color = dens_color) +
-    ggtitle(paste("Simulation-Based and Theoretical", 
-                  statistic_text, "Null Distributions")) +
+    ggtitle(glue_null(
+      "Simulation-Based and Theoretical {statistic_text} Null Distributions"
+    )) +
     xlab("zstat") +
     ylab("")
 }
@@ -306,7 +308,7 @@ theory_chisq_plot <- function(deg_freedom,
     stat_function(mapping = aes(x), fun = dchisq, 
                   args = list(df = deg_freedom), 
                   color = dens_color) +
-    ggtitle(paste("Theoretical", statistic_text, "Null Distribution")) +
+    ggtitle(glue_null("Theoretical {statistic_text} Null Distribution")) +
     xlab("") +
     ylab("")
 }
@@ -336,8 +338,9 @@ both_chisq_plot <- function(data, deg_freedom, statistic_text = "Chi-Square",
   infer_chisq_plot +
     stat_function(fun = dchisq, args = list(df = deg_freedom), 
                   color = dens_color) +
-    ggtitle(paste("Simulation-Based and Theoretical", 
-                  statistic_text, "Null Distributions")) +
+    ggtitle(glue_null(
+      "Simulation-Based and Theoretical {statistic_text} Null Distributions"
+    )) +
     xlab("chisqstat") +
     ylab("")
 }

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -131,9 +131,10 @@ chisq_test <- function(data, formula, #response = NULL, explanatory = NULL,
                        ...){
 
   if(is.null(f_rhs(formula)))
-    stop(paste("`chisq_test()` currently only has functionality for",
-               "Chi-Square Test of Independence, not for Chi-Square",
-               "Goodness of Fit."))
+    stop_glue(
+      "`chisq_test()` currently only has functionality for ",
+      "Chi-Square Test of Independence, not for Chi-Square Goodness of Fit."
+    )
   ## Only currently working with formula interface
   explanatory_var <- f_rhs(formula)
   response_var <- f_lhs(formula)
@@ -154,10 +155,11 @@ chisq_test <- function(data, formula, #response = NULL, explanatory = NULL,
 chisq_stat <- function(data, formula, ...){
   
   if(is.null(f_rhs(formula))){
-    stop(paste("`chisq_stat()` currently only has functionality for",
-               "Chi-Square Test of Independence, not for Chi-Square",
-               "Goodness of Fit. Use `specify() %>% hypothesize()",
-               "%>% calculate()` instead."))
+    stop_glue(
+      "`chisq_stat()` currently only has functionality for ",
+      "Chi-Square Test of Independence, not for Chi-Square Goodness of Fit. ",
+      "Use `specify() %>% hypothesize() %>% calculate()` instead."
+    )
   } else {
     data %>%
       specify(formula = formula, ...) %>%
@@ -170,6 +172,5 @@ check_conf_level <- function(conf_level){
   if(class(conf_level) != "numeric" |
      conf_level < 0 |
      conf_level > 1)
-    stop("The `conf_level` argument must be a number between 0 and 1.",
-         call. = FALSE)
+    stop_glue("The `conf_level` argument must be a number between 0 and 1.")
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,35 @@
 context("utils")
 
+null_val <- NULL
+
+test_that("stop_glue handles `NULL`", {
+  expect_error(stop_glue("Hello {null_val}", "!"), "NULL")
+})
+
+test_that("warning_glue handles `NULL`", {
+  expect_warning(warning_glue("Hello {null_val}", "!"), "NULL")
+})
+
+test_that("message_glue handles `NULL`", {
+  expect_message(message_glue("Hello {null_val}", "!"), "NULL")
+})
+
+test_that("glue_null works", {
+  adj <- "quick"
+  
+  expect_equal(
+    glue_null(
+      "The {adj} brown {null_val} jumps ", "over the lazy {NULL}."
+    ),
+    "The quick brown NULL jumps over the lazy NULL."
+  )
+  
+  expect_equal(
+    glue_null("The {adj}", "brown", .sep = "-"),
+    "The quick-brown"
+  )
+})
+
 test_that("get_type works", {
   expect_equal(get_type(data.frame(x = 1)), "data.frame")
   expect_equal(get_type(list(x = 1)), "list")

--- a/tests/testthat/test-visualize.R
+++ b/tests/testthat/test-visualize.R
@@ -316,8 +316,8 @@ test_that("obs_stat as a data.frame works", {
 
 
 test_that('method = "both" behaves nicely', {
-  # stop(paste0('`generate()` and `calculate()` are both required ', 
-  # 'to be done prior to `visualize(method = "both")`'))
+  # stop_glue('`generate()` and `calculate()` are both required ',
+  #           'to be done prior to `visualize(method = "both")`')
   expect_error(iris_tbl %>% 
                  specify(Petal.Width ~ NULL) %>%
                  hypothesize(null = "point", mu = 4) %>%


### PR DESCRIPTION
This is a PR for issue #155.
I ended up replacing all `stop()`, `warning()`, and `message()` with `stop_glue()`, `warning_glue()`, and `message_glue()` in which:
- `call. = FALSE` is default. This goes well with [tidyverse style guide](http://style.tidyverse.org/error-messages.html#problem-statement) and might be considered as part of #102.
- If supplied object evaluates in `NULL` it is printed as 'NULL' (as discussed in issue). Separate wrapper `glue_null()` for `glue::glue()` is implemented for this.

Also `glue_null()` is used instead of `paste()` and `paste0()`.

**Note** that current version of `print.infer()` has slightly different behavior in case input hasn't any of desired three attributes: it prints empty line before printing tibble. This can happen only if `infer` object wasn't properly created, so it can be a useful feature (indicate that something is wrong). If this deviation is crucial, it is totally possible to avoid that.