### PR TITLE
Fix `calculate()` to not depend on order of `p` (fixes #122).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Update documentation code to follow tidyverse style guide (#159).
 - Remove help page for internal `set_params()` (#165).
 - Fully use {tibble} (#166).
+- Fix `calculate()` to not depend on order of `p` for `type = "simulate"` (#122).
 
 # infer 0.3.1
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -233,10 +233,13 @@ calc_impl.Chisq <- function(stat, x, order, ...) {
     # Chi-Square Goodness of Fit
     if (!is.null(attr(x, "params"))) {
       # When `hypothesize()` has been called
+      p_levels <- get_par_levels(x)
       x %>%
         dplyr::summarize(
           stat = stats::chisq.test(
-            table(!!(attr(x, "response"))), p = attr(x, "params")
+            # Ensure correct ordering of parameters
+            table(!!(attr(x, "response")))[p_levels],
+            p = attr(x, "params")
           )$stat
         )
     } else {

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -409,3 +409,20 @@ test_that("One sample t bootstrap is working", {
       calculate(stat = "t")
   )
 })
+
+test_that("calculate doesn't depend on order of `p` (#122)", {
+  calc_chisq <- function(p) {
+    set.seed(111)
+    
+    iris %>%
+      specify(Species ~ NULL) %>%
+      hypothesize(null = "point", p = p) %>%
+      generate(reps = 10, type = "simulate") %>%
+      calculate("Chisq")
+  }
+  
+  expect_equal(
+    calc_chisq(c("versicolor" = 0.25, "setosa" = 0.5, "virginica" = 0.25)),
+    calc_chisq(c("virginica" = 0.25, "versicolor" = 0.25, "setosa" = 0.5))
+  )
+})


### PR DESCRIPTION
The reason was that `table()` inside of `calc_impl.Chisq()` computes values in alphabetical order of input levels. If proportion are supplied in that order, everything was fine. Fixed with reordering the output of that `table()`.