### PR TITLE
Add new options for `calculate()` (issue #50)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Reduce code duplication (#173).
 - Make transparancy in `visualize()` to not depend on method and data volume.
 - Make `visualize()` work for "One sample t" theoretical type with `method = "both"`.
+- Add `stat = "sum"` and `stat = "count"` options to `calculate()` (#50).
 
 # infer 0.3.1
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -3,9 +3,9 @@
 #' @param x The output from [generate()] for computation-based inference or the
 #'   output from [hypothesize()] piped in to here for theory-based inference.
 #' @param stat A string giving the type of the statistic to calculate. Current
-#'   options include `"mean"`, `"median"`, `"sum"`, `"sd"`, `"prop"`, `"diff in
-#'   means"`, `"diff in medians"`, `"diff in props"`, `"Chisq"`, `"F"`, `"t"`,
-#'   `"z"`, `"slope"`, and `"correlation"`.
+#'   options include `"mean"`, `"median"`, `"sum"`, `"sd"`, `"prop"`, `"count"`,
+#'   `"diff in means"`, `"diff in medians"`, `"diff in props"`, `"Chisq"`,
+#'   `"F"`, `"t"`, `"z"`, `"slope"`, and `"correlation"`.
 #' @param order A string vector of specifying the order in which the levels of
 #'   the explanatory variable should be ordered for subtraction, where `order =
 #'   c("first", "second")` means `("first" - "second")` Needed for inference on
@@ -29,9 +29,9 @@
 #' @export
 calculate <- function(x,
                       stat = c(
-                        "mean", "median", "sum", "sd", "prop", "diff in means",
-                        "diff in medians", "diff in props", "Chisq", "F",
-                        "slope", "correlation", "t", "z"
+                        "mean", "median", "sum", "sd", "prop", "count",
+                        "diff in means", "diff in medians", "diff in props",
+                        "Chisq", "F", "slope", "correlation", "t", "z"
                       ),
                       order = NULL,
                       ...) {
@@ -53,7 +53,7 @@ calculate <- function(x,
       x$replicate <- 1L
     } else if (
       stat %in% c(
-        "mean", "median", "sum", "sd", "prop", "diff in means",
+        "mean", "median", "sum", "sd", "prop", "count", "diff in means",
         "diff in medians", "diff in props", "slope", "correlation"
       )
     ) {
@@ -62,7 +62,7 @@ calculate <- function(x,
         "implemented) for `stat` = \"{stat}\". Are you missing ",
         "a `generate()` step?"
       )
-    } else if (!(stat %in% c("Chisq", "prop"))) {
+    } else if (!(stat %in% c("Chisq", "prop", "count"))) {
       # From `hypothesize()` to `calculate()`
       # Catch-all if generate was not called
 #      warning_glue("You unexpectantly went from `hypothesize()` to ",
@@ -144,34 +144,41 @@ calc_impl.sum <- calc_impl_one_f(sum)
 
 calc_impl.sd <- calc_impl_one_f(stats::sd)
 
-calc_impl.prop <- function(type, x, order, ...) {
-  col <- base::setdiff(names(x), "replicate")
-
-  ## No longer needed with implementation of `check_point_params()`
-  # if (!is.factor(x[[col]])) {
-  #   stop_glue(
-  #     "Calculating a {stat} here is not appropriate since the `{col}` ",
-  #     "variable is not a factor."
-  #   )
-  # }
-
-  if (is_nuat(x, "success")) {
-    stop_glue(
-      'To calculate a proportion, the `"success"` argument must be provided ',
-      'in `specify()`.'
-    )
-  }
-
-  success <- attr(x, "success")
-  x %>%
-    dplyr::group_by(replicate) %>%
-    dplyr::summarize(
-      stat = mean(
-        # rlang::eval_tidy(col) == rlang::eval_tidy(success), ...
-        !!sym(col) == success, ...
+calc_impl_success_f <- function(f, output_name) {
+  function(type, x, order, ...) {
+    col <- base::setdiff(names(x), "replicate")
+    
+    ## No longer needed with implementation of `check_point_params()`
+    # if (!is.factor(x[[col]])) {
+    #   stop_glue(
+    #     "Calculating a {stat} here is not appropriate since the `{col}` ",
+    #     "variable is not a factor."
+    #   )
+    # }
+    
+    if (is_nuat(x, "success")) {
+      stop_glue(
+        'To calculate a {output_name}, the `"success"` argument must be ',
+        'provided in `specify()`.'
       )
-    )
+    }
+    
+    success <- attr(x, "success")
+    x %>%
+      dplyr::group_by(replicate) %>%
+      dplyr::summarize(stat = f(!!sym(col), success))
+  }
 }
+
+calc_impl.prop <- calc_impl_success_f(
+  f = function(response, success, ...) {mean(response == success, ...)},
+  output_name = "proportion"
+)
+
+calc_impl.count <- calc_impl_success_f(
+  f = function(response, success, ...) {sum(response == success, ...)},
+  output_name = "count"
+)
 
 calc_impl.F <- function(type, x, order, ...) {
   x %>%

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -3,9 +3,9 @@
 #' @param x The output from [generate()] for computation-based inference or the
 #'   output from [hypothesize()] piped in to here for theory-based inference.
 #' @param stat A string giving the type of the statistic to calculate. Current
-#'   options include `"mean"`, `"median"`, `"sd"`, `"prop"`, `"diff in means"`,
-#'   `"diff in medians"`, `"diff in props"`, `"Chisq"`, `"F"`, `"t"`, `"z"`,
-#'   `"slope"`, and `"correlation"`.
+#'   options include `"mean"`, `"median"`, `"sum"`, `"sd"`, `"prop"`, `"diff in
+#'   means"`, `"diff in medians"`, `"diff in props"`, `"Chisq"`, `"F"`, `"t"`,
+#'   `"z"`, `"slope"`, and `"correlation"`.
 #' @param order A string vector of specifying the order in which the levels of
 #'   the explanatory variable should be ordered for subtraction, where `order =
 #'   c("first", "second")` means `("first" - "second")` Needed for inference on
@@ -29,7 +29,7 @@
 #' @export
 calculate <- function(x,
                       stat = c(
-                        "mean", "median", "sd", "prop", "diff in means",
+                        "mean", "median", "sum", "sd", "prop", "diff in means",
                         "diff in medians", "diff in props", "Chisq", "F",
                         "slope", "correlation", "t", "z"
                       ),
@@ -53,8 +53,8 @@ calculate <- function(x,
       x$replicate <- 1L
     } else if (
       stat %in% c(
-        "mean", "median", "sd", "prop", "diff in means", "diff in medians",
-        "diff in props", "slope", "correlation"
+        "mean", "median", "sum", "sd", "prop", "diff in means",
+        "diff in medians", "diff in props", "slope", "correlation"
       )
     ) {
       stop_glue(
@@ -139,6 +139,8 @@ calc_impl_one_f <- function(f) {
 calc_impl.mean <- calc_impl_one_f(mean)
 
 calc_impl.median <- calc_impl_one_f(stats::median)
+
+calc_impl.sum <- calc_impl_one_f(sum)
 
 calc_impl.sd <- calc_impl_one_f(stats::sd)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,7 +129,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
   # but that's not as helpful to beginners with the cryptic error msg
   if (
     !stat %in% c(
-      "mean", "median", "sd", "prop", "diff in means", "diff in medians",
+      "mean", "median", "sum", "sd", "prop", "diff in means", "diff in medians",
       "diff in props", "Chisq", "F", "slope", "correlation", "t", "z"
     )
   ) {
@@ -166,7 +166,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
 }
 
 check_for_numeric_stat <- function(x, stat) {
-  if (stat %in% c("mean", "median", "sd")) {
+  if (stat %in% c("mean", "median", "sum", "sd")) {
     col <- base::setdiff(names(x), "replicate")
 
     if (!is.numeric(x[[as.character(col)]])) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,8 +129,9 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
   # but that's not as helpful to beginners with the cryptic error msg
   if (
     !stat %in% c(
-      "mean", "median", "sum", "sd", "prop", "diff in means", "diff in medians",
-      "diff in props", "Chisq", "F", "slope", "correlation", "t", "z"
+      "mean", "median", "sum", "sd", "prop", "count", "diff in means",
+      "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation",
+      "t", "z"
     )
   ) {
     stop_glue(

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -4,18 +4,17 @@
 \alias{calculate}
 \title{Calculate summary statistics}
 \usage{
-calculate(x, stat = c("mean", "median", "sd", "prop", "diff in means",
-  "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation",
-  "t", "z"), order = NULL, ...)
+calculate(x, stat = c("mean", "median", "sum", "sd", "prop",
+  "diff in means", "diff in medians", "diff in props", "Chisq", "F",
+  "slope", "correlation", "t", "z"), order = NULL, ...)
 }
 \arguments{
 \item{x}{The output from \code{\link[=generate]{generate()}} for computation-based inference or the
 output from \code{\link[=hypothesize]{hypothesize()}} piped in to here for theory-based inference.}
 
 \item{stat}{A string giving the type of the statistic to calculate. Current
-options include \code{"mean"}, \code{"median"}, \code{"sd"}, \code{"prop"}, \code{"diff in means"},
-\code{"diff in medians"}, \code{"diff in props"}, \code{"Chisq"}, \code{"F"}, \code{"t"}, \code{"z"},
-\code{"slope"}, and \code{"correlation"}.}
+options include \code{"mean"}, \code{"median"}, \code{"sum"}, \code{"sd"}, \code{"prop"}, \code{"diff in means"}, \code{"diff in medians"}, \code{"diff in props"}, \code{"Chisq"}, \code{"F"}, \code{"t"},
+\code{"z"}, \code{"slope"}, and \code{"correlation"}.}
 
 \item{order}{A string vector of specifying the order in which the levels of
 the explanatory variable should be ordered for subtraction, where \code{order = c("first", "second")} means \code{("first" - "second")} Needed for inference on

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -4,7 +4,7 @@
 \alias{calculate}
 \title{Calculate summary statistics}
 \usage{
-calculate(x, stat = c("mean", "median", "sum", "sd", "prop",
+calculate(x, stat = c("mean", "median", "sum", "sd", "prop", "count",
   "diff in means", "diff in medians", "diff in props", "Chisq", "F",
   "slope", "correlation", "t", "z"), order = NULL, ...)
 }
@@ -13,8 +13,9 @@ calculate(x, stat = c("mean", "median", "sum", "sd", "prop",
 output from \code{\link[=hypothesize]{hypothesize()}} piped in to here for theory-based inference.}
 
 \item{stat}{A string giving the type of the statistic to calculate. Current
-options include \code{"mean"}, \code{"median"}, \code{"sum"}, \code{"sd"}, \code{"prop"}, \code{"diff in means"}, \code{"diff in medians"}, \code{"diff in props"}, \code{"Chisq"}, \code{"F"}, \code{"t"},
-\code{"z"}, \code{"slope"}, and \code{"correlation"}.}
+options include \code{"mean"}, \code{"median"}, \code{"sum"}, \code{"sd"}, \code{"prop"}, \code{"count"},
+\code{"diff in means"}, \code{"diff in medians"}, \code{"diff in props"}, \code{"Chisq"},
+\code{"F"}, \code{"t"}, \code{"z"}, \code{"slope"}, and \code{"correlation"}.}
 
 \item{order}{A string vector of specifying the order in which the levels of
 the explanatory variable should be ordered for subtraction, where \code{order = c("first", "second")} means \code{("first" - "second")} Needed for inference on

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -428,3 +428,22 @@ test_that("calc_impl_one_f works", {
 test_that("calc_impl_diff_f works", {
   expect_true(is.function(calc_impl_diff_f(mean)))
 })
+
+test_that("calc_impl.sum works", {
+  expect_equal(
+    iris_tbl %>%
+      specify(Petal.Width ~ NULL) %>%
+      calculate(stat = "sum") %>%
+      `[[`(1),
+    sum(iris_tbl$Petal.Width)
+  )
+  
+  gen_iris16 <- iris_tbl %>%
+    specify(Petal.Width ~ NULL) %>%
+    generate(10)
+  
+  expect_equal(
+    gen_iris16 %>% calculate(stat = "sum"),
+    gen_iris16 %>% dplyr::summarise(stat = sum(Petal.Width))
+  )
+})


### PR DESCRIPTION
This is a PR following a conversation in #50.
Adding new options to `calculate()` isn't straightforward as I hoped: they still should be carefully added to different types of checks. During that I treated `"sum"` as `"mean"` (without possibility of hypothesising about point value) and `"count"` as `"prop"` (again without point hypothesis).