### PR TITLE
More verbose error message for argument checks in `specify()`

### DIFF
--- a/R/specify.R
+++ b/R/specify.R
@@ -44,7 +44,9 @@ specify <- function(x, formula, response = NULL,
   }
   if (methods::hasArg(formula)) {
     if (!rlang::is_formula(formula)) {
-      stop_glue("The `formula` argument is not recognized as a formula.")
+      stop_glue("The first unnamed argument must be a formula.
+                * You passed in '{get_type(formula)}'.
+                * Did you forget to name one or more aguments?")
     }
   }
 

--- a/R/specify.R
+++ b/R/specify.R
@@ -45,8 +45,8 @@ specify <- function(x, formula, response = NULL,
   if (methods::hasArg(formula)) {
 
     tryCatch(
-       formula_arg_is_formula <- rlang::is_formula(formula)
-      , error = function(e) {
+       formula_arg_is_formula <- rlang::is_formula(formula), 
+      error = function(e) {
         stop_glue("The argument you passed in for the formula does not exist.
                   * Were you trying to pass in an unquoted column name?
                   * Did you forget to name one or more arguments?")

--- a/R/specify.R
+++ b/R/specify.R
@@ -43,7 +43,16 @@ specify <- function(x, formula, response = NULL,
     stop_glue("Please give the `response` variable.")
   }
   if (methods::hasArg(formula)) {
-    if (!rlang::is_formula(formula)) {
+
+    tryCatch(
+       formula_arg_is_formula <- rlang::is_formula(formula)
+      , error = function(e) {
+        stop_glue("The argument you passed in for the formula does not exist.
+                  * Were you trying to pass in an unquoted column name?
+                  * Did you forget to name one or more aguments?")
+      }
+    )
+    if (!formula_arg_is_formula) {
       stop_glue("The first unnamed argument must be a formula.
                 * You passed in '{get_type(formula)}'.
                 * Did you forget to name one or more aguments?")

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -57,6 +57,15 @@ test_that("sensible output", {
 
 test_that("formula argument is a formula", {
   expect_error(specify(mtcars_df, formula = "vs", success = 1))
+
+  # Issue #110: https://github.com/tidymodels/infer/issues/110
+  expect_error(specify(mtcars, am, success = "1"))
+  expect_error(specify(mtcars, response = am, "1"))
+  expect_silent({
+    mtcars %>%
+      dplyr::mutate(am = factor(am)) %>%
+      specify(response = am, success = "1")
+  })
 })
 
 test_that("is_complete works", {


### PR DESCRIPTION
This addresses issue #110.