### PR TITLE
Use pull() only (without select()) in vignettes

### DIFF
--- a/vignettes/chisq_test.Rmd
+++ b/vignettes/chisq_test.Rmd
@@ -137,7 +137,6 @@ chisq_null_distn %>%
 ```{r}
 fli_small %>% 
   chisq_test(formula = origin ~ season) %>% 
-  dplyr::select(p_value) %>% 
-  dplyr::pull()
+  dplyr::pull(p_value)
 ```
 

--- a/vignettes/flights_examples.Rmd
+++ b/vignettes/flights_examples.Rmd
@@ -259,8 +259,7 @@ null_distn %>%
 slope_hat <- lm(arr_delay ~ dep_delay, data = fli_small) %>% 
   broom::tidy() %>% 
   filter(term == "dep_delay") %>% 
-  select(estimate) %>% 
-  pull()
+  pull(estimate)
 null_distn <- fli_small %>%
    specify(arr_delay ~ dep_delay) %>% 
    hypothesize(null = "independence") %>%
@@ -348,8 +347,7 @@ c(lower = d_hat - 2 * sd(boot),
 slope_hat <- lm(arr_delay ~ dep_delay, data = fli_small) %>% 
   broom::tidy() %>% 
   filter(term == "dep_delay") %>% 
-  select(estimate) %>% 
-  pull()
+  pull(estimate)
 boot <- fli_small %>%
    specify(arr_delay ~ dep_delay) %>% 
    generate(reps = 1000, type = "bootstrap") %>%

--- a/vignettes/two_sample_t.Rmd
+++ b/vignettes/two_sample_t.Rmd
@@ -69,8 +69,7 @@ Or using `t_test` in `infer`
 obs_t <- fli_small %>% 
   t_test(formula = arr_delay ~ half_year, alternative = "two_sided",
          order = c("h1", "h2")) %>% 
-  dplyr::select(statistic) %>% 
-  dplyr::pull()
+  dplyr::pull(statistic)
 ```
 
 The observed $t$ statistic is `r obs_t`.
@@ -142,7 +141,6 @@ fli_small %>%
   t_test(formula = arr_delay ~ half_year,
          alternative = "two_sided",
          order = c("h1", "h2")) %>% 
-  dplyr::select(p_value) %>% 
-  dplyr::pull()
+  dplyr::pull(p_value)
 ```
 


### PR DESCRIPTION
Avoids a tiny bit of redundancy in code examples. Cleaner PR than #200.