### PR TITLE
Update `get_p_value()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # infer 0.3.1.9000
 
+## Breaking changes
+
+- Changed method of computing two-sided p-value to a more conventional one. It also makes `get_pvalue()` and `visualize()` more aligned (#205).
+
 ## Deprecation changes
 
 - Deprecated `p_value()` (use `get_p_value()` instead) (#180).

--- a/R/get_p_value.R
+++ b/R/get_p_value.R
@@ -42,7 +42,7 @@ NULL
 #' @export
 get_p_value <- function(x, obs_stat, direction) {
   check_type(x, is.data.frame)
-  if(!is_generated(x) & is_hypothesized(x)) {
+  if (!is_generated(x) & is_hypothesized(x)) {
     stop_glue(
       "Theoretical p-values are not yet supported.",
       "`x` should be the result of calling `generate()`.",
@@ -52,11 +52,7 @@ get_p_value <- function(x, obs_stat, direction) {
   obs_stat <- check_obs_stat(obs_stat)
   check_direction(direction)
 
-  pvalue <- simulation_based_p_value(
-    x = x, 
-    obs_stat = obs_stat,
-    direction = direction
-  )
+  simulation_based_p_value(x = x, obs_stat = obs_stat, direction = direction)
 
   ## Theoretical-based p-value
   # Could be more specific
@@ -71,8 +67,6 @@ get_p_value <- function(x, obs_stat, direction) {
   #                     obs_stat = obs_stat,
   #                     direction = direction)
   # }
-
-  return(pvalue)
 }
 
 #' @rdname get_p_value

--- a/R/get_p_value.R
+++ b/R/get_p_value.R
@@ -40,8 +40,7 @@ NULL
 
 #' @rdname get_p_value
 #' @export
-get_p_value <- function(x, obs_stat, direction){
-
+get_p_value <- function(x, obs_stat, direction) {
   check_type(x, is.data.frame)
   if(!is_generated(x) & is_hypothesized(x)) {
     stop_glue(
@@ -56,7 +55,8 @@ get_p_value <- function(x, obs_stat, direction){
   pvalue <- simulation_based_p_value(
     x = x, 
     obs_stat = obs_stat,
-    direction = direction)
+    direction = direction
+  )
 
   ## Theoretical-based p-value
   # Could be more specific
@@ -81,26 +81,22 @@ get_pvalue <- function(x, obs_stat, direction) {
   get_p_value(x = x, obs_stat = obs_stat, direction = direction)
 }
 
-simulation_based_p_value <- function(x, obs_stat, direction){
-
-  if(direction %in% c("less", "left")){
+simulation_based_p_value <- function(x, obs_stat, direction) {
+  if (direction %in% c("less", "left")) {
     p_value <- x %>%
       dplyr::summarize(p_value = mean(stat <= obs_stat))
-  }
-  else if(direction %in% c("greater", "right")){
+  } else if (direction %in% c("greater", "right")) {
     p_value <- x %>%
       dplyr::summarize(p_value = mean(stat >= obs_stat))
-  }
-  else{
+  } else {
     p_value <- x %>% two_sided_p_value(obs_stat = obs_stat)
   }
 
   p_value
 }
 
-two_sided_p_value <- function(x, obs_stat){
-
-  if(stats::median(x$stat) >= obs_stat){
+two_sided_p_value <- function(x, obs_stat) {
+  if (stats::median(x$stat) >= obs_stat) {
     basic_p_value <- get_percentile(x$stat, obs_stat) +
       (1 - get_percentile(x$stat, stats::median(x$stat) +
           stats::median(x$stat) - obs_stat))
@@ -110,13 +106,14 @@ two_sided_p_value <- function(x, obs_stat){
           stats::median(x$stat) - obs_stat))
   }
 
-  if(basic_p_value >= 1)
+  if (basic_p_value >= 1) {
     # Catch all if adding both sides produces a number
     # larger than 1. Should update with test in that
     # scenario instead of using >=
     return(tibble::tibble(p_value = 1))
-  else
+  } else {
     return(tibble::tibble(p_value = basic_p_value))
+  }
 }
 
 is_generated <- function(x) {

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -538,16 +538,6 @@ check_shade_confidence_interval_args <- function(color, fill) {
   }
 }
 
-get_percentile <- function(vector, observation) {
-  stats::ecdf(vector)(observation)
-}
-
-mirror_obs_stat <- function(vector, observation) {
-  obs_percentile <- get_percentile(vector, observation)
-  
-  stats::quantile(vector, probs = 1 - obs_percentile)
-}
-
 short_theory_type <- function(x) {
   theory_attr <- attr(x, "theory_type")
   theory_types <- list(
@@ -620,6 +610,12 @@ two_tail_data <- function(obs_stat, direction) {
       x_max = c(min(obs_stat, second_border), Inf)
     )
   }
+}
+
+mirror_obs_stat <- function(vector, observation) {
+  obs_percentile <- stats::ecdf(vector)(observation)
+  
+  stats::quantile(vector, probs = 1 - obs_percentile)
 }
 
 get_viz_method <- function(data) {

--- a/man/get_p_value.Rd
+++ b/man/get_p_value.Rd
@@ -19,7 +19,7 @@ extreme than this).}
 \code{"two_sided"}. Can also use \code{"left"}, \code{"right"}, or \code{"both"}.}
 }
 \value{
-A 1x1 data frame with value between 0 and 1.
+A 1x1 \link[tibble:tibble]{tibble} with value between 0 and 1.
 }
 \description{
 Simulation-based methods are (currently only) supported.

--- a/man/visualize.Rd
+++ b/man/visualize.Rd
@@ -68,11 +68,12 @@ the theoretical distribution (or both!).
 \details{
 In order to make visualization workflow more straightforward and
 explicit \code{visualize()} now only should be used to plot statistics directly.
-That is why arguments, not related to this task, are deprecated and will be
+That is why arguments not related to this task are deprecated and will be
 removed in a future release of \{infer\}.
 
-To add information related to p-value use \code{\link[=shade_p_value]{shade_p_value()}}. To add
-information related to confidence interval use \code{\link[=shade_confidence_interval]{shade_confidence_interval()}}.
+To add to plot information related to p-value use \code{\link[=shade_p_value]{shade_p_value()}}. To add
+to plot information related to confidence interval use
+\code{\link[=shade_confidence_interval]{shade_confidence_interval()}}.
 }
 \examples{
 # Permutations to create a simulation-based null distribution for

--- a/tests/testthat/test-get_p_value.R
+++ b/tests/testthat/test-get_p_value.R
@@ -1,60 +1,36 @@
 context("get_p_value")
 
 set.seed(2018)
-test_df <- tibble::tibble(stat = rnorm(100))
+test_df <- tibble::tibble(
+  stat = sample(c(
+    -5, -4, -4, -4, -1, -0.5, rep(0, 6), 1, 1, 3.999, 4, 4, 4.001, 5, 5
+  ))
+)
 
 test_that("direction is appropriate", {
   expect_error(test_df %>% get_p_value(obs_stat = 0.5, direction = "righ"))
 })
 
-test_that("get_p_value makes sense", {
-  expect_silent(
-    test_df %>% 
-      get_p_value(obs_stat = 0.7, direction = "right")
-    )
-  expect_lt(
-    iris_calc %>%
-      get_p_value(obs_stat = 0.1, direction = "right") %>%
-      dplyr::pull(),
-    expected = 0.1
-  )
-  expect_gt(
-    iris_calc %>%
-      get_p_value(obs_stat = -0.1, direction = "greater") %>%
-      dplyr::pull(),
-    expected = 0.9
-  )
+test_that("get_p_value works", {
+  expect_equal(get_p_value(test_df, 4, "right")[[1]][1], 5/20)
+  expect_equal(get_p_value(test_df, 4, "left")[[1]][1], 17/20)
+  expect_equal(get_p_value(test_df, 4, "both")[[1]][1], 10/20)
+  
+  expect_equal(get_p_value(test_df, 0, "right")[[1]][1], 14/20)
+  expect_equal(get_p_value(test_df, 0, "left")[[1]][1], 12/20)
+  # This is also a check for not returning value more than 1
+  expect_equal(get_p_value(test_df, 0, "both")[[1]][1], 1)
+  
+  expect_equal(get_p_value(test_df, -3.999, "right")[[1]][1], 16/20)
+  expect_equal(get_p_value(test_df, -3.999, "left")[[1]][1], 4/20)
+  expect_equal(get_p_value(test_df, -3.999, "both")[[1]][1], 8/20)
+  
   expect_equal(
-    iris_calc %>%
-      get_p_value(obs_stat = median(iris_calc$stat), direction = "both") %>%
-      dplyr::pull(),
-    expected = 1
+    get_p_value(test_df, 4, "greater"), get_p_value(test_df, 4, "right")
   )
-  expect_lt(
-    iris_calc %>%
-      get_p_value(obs_stat = -0.2, direction = "left") %>%
-      dplyr::pull(),
-    expected = 0.02
-  )
-  expect_gt(
-    iris_calc %>%
-      get_p_value(obs_stat = -0.2, direction = "right") %>%
-      dplyr::pull(),
-    expected = 0.98
-  )
+  expect_equal(get_p_value(test_df, 4, "less"), get_p_value(test_df, 4, "left"))
   expect_equal(
-    iris_calc %>%
-      get_p_value(
-        obs_stat = median(iris_calc$stat) + 1, direction = "two_sided"
-      ) %>%
-      dplyr::pull(),
-    expected = 0
-  )
-  expect_error(
-    iris_calc %>%
-      get_p_value(
-        obs_stat = median(iris_calc$stat) + 1, direction = "wrong"
-      )
+    get_p_value(test_df, 4, "two_sided"), get_p_value(test_df, 4, "both")
   )
 })
 
@@ -69,5 +45,4 @@ test_that("theoretical p-value not supported error", {
       calculate(stat = "F") %>% 
       get_p_value(obs_stat = obs_F, direction = "right")
   )
-  
 })

--- a/tests/testthat/test-visualize.R
+++ b/tests/testthat/test-visualize.R
@@ -297,8 +297,8 @@ test_that("visualize basic tests", {
   )
 })
 
-test_that("get_percentile works", {
-  expect_equal(get_percentile(1:10, 4), 0.4)
+test_that("mirror_obs_stat works", {
+  expect_equal(mirror_obs_stat(1:10, 4), c(`60%` = 6.4))
 })
 
 test_that("obs_stat as a data.frame works", {


### PR DESCRIPTION
This PR mainly is about #205. I also ended up:

- Rewriting majority of tests for p-value computation, because previous ones didn't trigger after I made a change in method.
- Making `get_p_value()` always return tibble (as other functions do).

**Note** that method change has considerable effect on vignettes (especially 'observed_stat_examples.Rmd').