### PR TITLE
Suppress chisq warnings

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -232,7 +232,7 @@ calc_impl.Chisq <- function(type, x, order, ...) {
       p_levels <- get_par_levels(x)
       x %>%
         dplyr::summarize(
-          stat = supressWarnings(stats::chisq.test(
+          stat = suppressWarnings(stats::chisq.test(
             # Ensure correct ordering of parameters
             table(!!(attr(x, "response")))[p_levels],
             p = attr(x, "params")

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -232,12 +232,12 @@ calc_impl.Chisq <- function(type, x, order, ...) {
       p_levels <- get_par_levels(x)
       x %>%
         dplyr::summarize(
-          stat = stats::chisq.test(
+          stat = supressWarnings(stats::chisq.test(
             # Ensure correct ordering of parameters
             table(!!(attr(x, "response")))[p_levels],
             p = attr(x, "params")
           )$stat
-        )
+        ))
     } else {
       # Straight from `specify()`
       stop_glue(

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -300,7 +300,7 @@ chisq_stat <- function(x, formula, response = NULL,
     mutate_if(is.character, as.factor) %>%
     mutate_if(is.logical, as.factor)
   
-  stats::chisq.test(table(x), ...) %>%
+  suppressWarnings(stats::chisq.test(table(x), ...)) %>%
     broom::glance() %>%
     dplyr::select(statistic) %>%
     pull()


### PR DESCRIPTION
This suppresses the warnings originating from `chisq.test()` in two spots where the function is only used to calculate a test statistic.