### PR TITLE
Restart use of vdiffr on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: r
-r:
-  - oldrel
-  - release
-  - devel
+
+matrix:
+  include:
+  - r: oldrel
+    # Don't use vdiffr on old R release
+    env: VDIFFR_RUN_TESTS=false
+  - r: release
+  - r: devel
+
 warnings_are_errors: true
 sudo: required
 cache: packages
@@ -11,7 +16,8 @@ latex: false
 env:
  global:
    - CRAN: http://cran.rstudio.com
-   - VDIFFR_RUN_TESTS: false
+   # Use vdiffr by default
+   - VDIFFR_RUN_TESTS: true
 
 notifications:
   email:

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,7 +1,4 @@
 library(testthat)
 library(infer)
 
-# Use fixed method of generating from a discrete uniform distribution
-RNGversion("3.5.0")
-
 test_check("infer")


### PR DESCRIPTION
This PR contains updates that enable use of {vdiffr} tests on Travis. The main reason why they didn't work was related to change of default random generation algorithm in 3.6.0 version. Command `RNGversion("3.5.0")` in 'tests/testthat.R' file somehow didn't affect the `vdiffr::manage_cases()` and `devtools::test()` functions, thus generating reference plots based on 3.6.0 random generation algorithm. However, R CMD CHECK respected that command and generated plots based on 3.5.0 version.

To enable use of {vdiffr} on Travis, I removed usage of 3.5.0 version from 'tests/testthat.R' and disabled {vdiffr} tests only on old R version. With this setup Travis actually performs {vdiffr} checks, see https://travis-ci.org/tidymodels/infer/builds/594139024.

cc @andrewpbray, @ismayc 