### PR TITLE
Refactor `set_params()` and `parse_variables()`

### DIFF
--- a/R/specify.R
+++ b/R/specify.R
@@ -167,7 +167,10 @@ check_var_correct <- function(x, var_name) {
   # Variable (if present) should be a symbolic column name
   if (!is.null(var)) {
     if (!rlang::is_symbolic(var)) {
-      stop_glue("The {var_name} variable should be symbolic.")
+      stop_glue(
+        "The {var_name} should be a bare variable name (not a string in ",
+        "quotation marks)."
+      )
     }
     
     if (!(as.character(var) %in% names(x))) {

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -26,14 +26,18 @@ test_that("data argument", {
 })
 
 test_that("response and explanatory arguments", {
-  expect_error(specify(mtcars_df, response = blah))
-  expect_error(specify(mtcars_df, response = "blah"))
-  expect_error(specify(mtcars_df, formula = mpg ~ blah))
-  expect_error(specify(blah ~ cyl))
-  expect_error(specify(mtcars_df, blah2 ~ cyl))
-  expect_error(specify(mtcars_df))
-  expect_error(specify(mtcars_df, formula = mpg ~ mpg))
-  expect_error(specify(mtcars_df, formula = mpg ~ "cyl"))
+  expect_error(specify(mtcars_df, response = blah), "response.*cannot be found")
+  expect_error(specify(mtcars_df, response = "blah"), "response.*symbolic")
+  expect_error(
+    specify(mtcars_df, formula = mpg ~ blah), "explanatory.*cannot be found"
+  )
+  expect_error(specify(mtcars_df, blah2 ~ cyl), "response.*cannot be found")
+  expect_error(specify(mtcars_df), "Supply.*response")
+  expect_error(specify(mtcars_df, formula = mpg ~ mpg), "different")
+  expect_error(specify(mtcars_df, formula = "mpg" ~ cyl), "response.*symbolic")
+  expect_error(
+    specify(mtcars_df, formula = mpg ~ "cyl"), "explanatory.*symbolic"
+  )
   expect_silent(specify(mtcars_df, formula = mpg ~ cyl))
 
   expect_error(specify(mtcars_df, formula = NULL ~ cyl), "NULL.*response")

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -76,3 +76,7 @@ test_that("is_complete works", {
   some_missing <- data.frame(vec = c(NA, 2, 3))
   expect_warning(specify(some_missing, response = vec))
 })
+
+test_that("specify doesn't have NSE issues (#256)", {
+  expect_silent(specify(tibble(x = 1:10), x ~ NULL))
+})

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -27,16 +27,20 @@ test_that("data argument", {
 
 test_that("response and explanatory arguments", {
   expect_error(specify(mtcars_df, response = blah), "response.*cannot be found")
-  expect_error(specify(mtcars_df, response = "blah"), "response.*symbolic")
+  expect_error(
+    specify(mtcars_df, response = "blah"), "response.*bare.*not a string"
+  )
   expect_error(
     specify(mtcars_df, formula = mpg ~ blah), "explanatory.*cannot be found"
   )
   expect_error(specify(mtcars_df, blah2 ~ cyl), "response.*cannot be found")
   expect_error(specify(mtcars_df), "Supply.*response")
   expect_error(specify(mtcars_df, formula = mpg ~ mpg), "different")
-  expect_error(specify(mtcars_df, formula = "mpg" ~ cyl), "response.*symbolic")
   expect_error(
-    specify(mtcars_df, formula = mpg ~ "cyl"), "explanatory.*symbolic"
+    specify(mtcars_df, formula = "mpg" ~ cyl), "response.*bare.*not a string"
+  )
+  expect_error(
+    specify(mtcars_df, formula = mpg ~ "cyl"), "explanatory.*bare.*not a string"
   )
   expect_silent(specify(mtcars_df, formula = mpg ~ cyl))
 


### PR DESCRIPTION
This PR:

- Fixes #256.
- Adds check for response and explanatory variables to be symbolic and not character (so that `specify(mtcars, response = "mpg")` throws informative error).