### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,23 @@ before_deploy:
   - Rscript -e 'pkgdown::build_site()'
 
 deploy:
-  provider: pages
-  skip-cleanup: true
-  keep-history: true
-  local-dir: docs
-  github_token: $GITHUBTRAVIS
-#  target-branch: gh-pages-dev
-  target-branch: gh-pages
+  - provider: pages
+    skip-cleanup: true
+    keep-history: true
+    local-dir: docs
+    github_token: $GITHUBTRAVIS
+    target-branch: gh-pages
+    on:
+      branch: master
+  - provider: pages
+    skip-cleanup: true
+    keep-history: true
+    local-dir: docs
+    github_token: $GITHUBTRAVIS
+    target-branch: gh-pages-dev
+    on:
+      branch: develop    
+
 
 after_success:
   - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
This allows for both the `develop` and `master` branches to deploy {pkgdown} sites to https://infer-dev.netlify.com (from `gh-pages-dev`) and https://infer.netlify.com (from `gh-pages`). Netlify settings have been updated so that it is looking at changes to be made to `gh-pages-dev` instead of the manual building of the `docs` folder on `develop`.