### PR TITLE
make hypothesizing null in t-tests more expressive (#232)

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -82,8 +82,8 @@ calculate <- function(x,
         "implemented) for `stat` = \"{stat}\". Are you missing ",
         "a `generate()` step?"
       )
-      } else if (!(stat %in% c("Chisq", "prop", "count")) |
-                 (stat == "t" & (attr(x, "theory_type") == "One sample t"))) {
+      } else if (!(stat %in% c("Chisq", "prop", "count")) &
+                 !(stat == "t" & (attr(x, "theory_type") == "One sample t"))) {
       # From `hypothesize()` to `calculate()`
       # Catch-all if generate was not called
 #      warning_glue("You unexpectantly went from `hypothesize()` to ",

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -82,7 +82,8 @@ calculate <- function(x,
         "implemented) for `stat` = \"{stat}\". Are you missing ",
         "a `generate()` step?"
       )
-      } else if (!(stat %in% c("Chisq", "prop", "count", "t"))) {
+      } else if (!(stat %in% c("Chisq", "prop", "count")) |
+                 (stat == "t" & (attr(x, "theory_type") == "One sample t"))) {
       # From `hypothesize()` to `calculate()`
       # Catch-all if generate was not called
 #      warning_glue("You unexpectantly went from `hypothesize()` to ",

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -82,7 +82,7 @@ calculate <- function(x,
         "implemented) for `stat` = \"{stat}\". Are you missing ",
         "a `generate()` step?"
       )
-    } else if (!(stat %in% c("Chisq", "prop", "count"))) {
+      } else if (!(stat %in% c("Chisq", "prop", "count", "t"))) {
       # From `hypothesize()` to `calculate()`
       # Catch-all if generate was not called
 #      warning_glue("You unexpectantly went from `hypothesize()` to ",
@@ -374,10 +374,19 @@ calc_impl.t <- function(type, x, order, ...) {
   else if (attr(x, "theory_type") == "One sample t") {
     # For bootstrap
     if (!is_hypothesized(x)) {
+      
+      if (is.null(list(...)$mu)) {
+        message_glue(
+          "No `mu` argument was hypothesized, so the t-test will ",
+          "assume a null hypothesis `mu = 0`."
+        )
+      }
+      
       x %>%
         dplyr::summarize(
           stat = stats::t.test(!!attr(x, "response"), ...)[["statistic"]]
         )
+      
     } else {
       # For hypothesis testing
       x %>%

--- a/man/chisq_stat.Rd
+++ b/man/chisq_stat.Rd
@@ -36,11 +36,11 @@ chisq_stat(gss, college ~ finrela)
 # follows a uniform distribution
 chisq_stat(gss, 
            response = finrela,
-           p = c("far below average" = .167,
-                 "below average" = .167,
-                 "average" = .167,
-                 "above average" = .167,
-                 "far above average" = .167,
-                 "DK" = .165))
+           p = c("far below average" = 1/6,
+                 "below average" = 1/6,
+                 "average" = 1/6,
+                 "above average" = 1/6,
+                 "far above average" = 1/6,
+                 "DK" = 1/6))
 
 }

--- a/man/chisq_test.Rd
+++ b/man/chisq_test.Rd
@@ -33,11 +33,11 @@ chisq_test(gss, college ~ finrela)
 # income class follows a uniform distribution
 chisq_test(gss, 
            response = finrela,
-           p = c("far below average" = .167,
-                 "below average" = .167,
-                 "average" = .167,
-                 "above average" = .167,
-                 "far above average" = .167,
-                 "DK" = .165))
+           p = c("far below average" = 1/6,
+                 "below average" = 1/6,
+                 "average" = 1/6,
+                 "above average" = 1/6,
+                 "far above average" = 1/6,
+                 "DK" = 1/6))
 
 }

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -361,6 +361,17 @@ test_that("One sample t hypothesis test is working", {
       generate(reps = 10) %>%
       calculate(stat = "t")
   )
+  
+  expect_message(
+    iris_tbl %>%
+      specify(response = Petal.Width) %>%
+      calculate(stat = "t"),
+    "the t-test will assume a null hypothesis"
+  )
+  
+  iris_tbl %>%
+    specify(response = Petal.Width) %>%
+    calculate(stat = "t", mu = 1)
 })
 
 test_that("specify done before calculate", {

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -80,7 +80,8 @@ Calculating the observed statistic,
 ```{r, message = FALSE, warning = FALSE}
 t_bar <- gss %>%
   specify(response = hours) %>%
-  calculate(stat = "t", mu = 40)
+  hypothesize(null = "point", mu = 40) %>%
+  calculate(stat = "t")
 ```
 
 Alternatively, using the wrapper to calculate the test statistic, 

--- a/vignettes/t_test.Rmd
+++ b/vignettes/t_test.Rmd
@@ -54,7 +54,8 @@ First, to calculate the observed statistic, we can use `specify()` and `calculat
 # calculate the observed statistic
 observed_statistic <- gss %>%
   specify(response = hours) %>%
-  calculate(stat = "t", mu = 40)
+  hypothesize(null = "point", mu = 40) %>%
+  calculate(stat = "t")
 ```
 
 The observed statistic is `r observed_statistic`. Now, we want to compare this statistic to a null distribution, generated under the assumption that the mean was actually 40, to get a sense of how likely it would be for us to see this observed statistic if the true number of hours worked per week in the population was really 40.


### PR DESCRIPTION
Some minor adjustments to `calculate()` to address #232--I'll comment some more explanation on that thread in a second, but the grammar for calculating one-sample t-test statistics should align with the grammar of the package a bit more clearly now. No breaking changes. I've also updated testing coverage and vignettes to reflect the change.

Also, in making adjustments re: @ismayc's comments on my last PR, I forgot to run `devtools::document()` on the updated files. The first commit (#
43859de) contains the updated docs.