### PR TITLE
Permutation for within subjects comparison

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -219,8 +219,7 @@ permute_once_within <- function(x, ...) {
   dots <- list(...)
 
   if (is_hypothesized(x) && (attr(x, "null") == "independence")) {
-       id <- attr(x, "subject") 
-       x %>% dplyr::group_by(id) %>% 
+       x %>% dplyr::group_by_at(attr(x, "subject")) %>% 
              dplyr::group_modify(~mutate(.,!!attr(x, "response"):=sample(!!attr(x, "response")))) %>%
              dplyr::ungroup() %>% 
              return 

--- a/R/specify.R
+++ b/R/specify.R
@@ -20,7 +20,9 @@
 #' @param success The level of `response` that will be considered a success, as
 #'   a string. Needed for inference on one proportion, a difference in
 #'   proportions, and corresponding z stats.
-#'
+#' @param subject For responses from subjects with repeated measures, the column
+#'   with the identifier can be specified so that the responses will be permuted
+#'   per subject.
 #' @return A tibble containing the response (and explanatory, if specified)
 #'   variable data.
 #'
@@ -36,7 +38,7 @@
 #' # ...or with named arguments!
 #' gss %>%
 #'   specify(response = age, explanatory = partyid)
-#'
+#' 
 #' # More in-depth explanation of how to use the infer package
 #' vignette("infer")
 #'

--- a/R/specify.R
+++ b/R/specify.R
@@ -46,7 +46,7 @@
 #' @importFrom methods hasArg
 #' @export
 specify <- function(x, formula, response = NULL,
-                    explanatory = NULL, success = NULL) {
+                    explanatory = NULL, subject = NULL, success = NULL) {
   check_type(x, is.data.frame)
 
   # Convert all character and logical variables to be factor variables
@@ -61,6 +61,14 @@ specify <- function(x, formula, response = NULL,
   explanatory <- enquo(explanatory)
   x <- parse_variables(x = x, formula = formula, 
                        response = response, explanatory = explanatory)
+
+  # Process "subject" arg
+  
+  if(!is.null(subject)) {
+
+      attr(x, "subject") <- subject
+
+  }
 
   # Process "success" arg
   response_col <- response_variable(x)
@@ -120,7 +128,8 @@ specify <- function(x, formula, response = NULL,
   # Select variables
   x <- x %>%
     select(one_of(c(
-      as.character((attr(x, "response"))), as.character(attr(x, "explanatory"))
+      as.character((attr(x, "response"))), as.character(attr(x, "explanatory")),
+      as.character(attr(x, "subject"))
     )))
 
   is_complete <- stats::complete.cases(x)


### PR DESCRIPTION
Hi,

Thanks for a great package!

I was interested in using infer to illustrate the difference between a between subjects and within subjects design (e.g. independent vs paired tests). I've added some functionality to specify() and generate() to allow the option for permute samples per subject, when the option subject="_column with subject identifier_" is included in specify().

<img width="740" alt="image" src="https://user-images.githubusercontent.com/6284366/72320784-5631d480-36dd-11ea-8324-9f27a5a67ac0.png">

<img width="740" alt="image" src="https://user-images.githubusercontent.com/6284366/72320886-88433680-36dd-11ea-8fcd-bde37cc3a194.png">

<img width="741" alt="image" src="https://user-images.githubusercontent.com/6284366/72320918-9d1fca00-36dd-11ea-8d5c-30376b324608.png">

<img width="739" alt="image" src="https://user-images.githubusercontent.com/6284366/72320961-ab6de600-36dd-11ea-957f-3c1fab7e2366.png">

Appreciate your review for incorporation in the package.

Cheers,
Kenneth