### PR TITLE
add error for piping after visualize()

### DIFF
--- a/R/shade_confidence_interval.R
+++ b/R/shade_confidence_interval.R
@@ -71,7 +71,7 @@ NULL
 shade_confidence_interval <- function(endpoints, color = "mediumaquamarine",
                                       fill = "turquoise", ...) {
   # argument checking
-  check_for_piped_visualize(NULL, NULL, color, endpoints)
+  check_for_piped_visualize(endpoints, color, fill)
   
   dots <- list(...)
   

--- a/R/shade_confidence_interval.R
+++ b/R/shade_confidence_interval.R
@@ -70,6 +70,9 @@ NULL
 #' @export
 shade_confidence_interval <- function(endpoints, color = "mediumaquamarine",
                                       fill = "turquoise", ...) {
+  # argument checking
+  check_for_piped_visualize(obs_stat, direction, color)
+  
   dots <- list(...)
   
   endpoints <- impute_endpoints(endpoints)

--- a/R/shade_confidence_interval.R
+++ b/R/shade_confidence_interval.R
@@ -71,7 +71,7 @@ NULL
 shade_confidence_interval <- function(endpoints, color = "mediumaquamarine",
                                       fill = "turquoise", ...) {
   # argument checking
-  check_for_piped_visualize(obs_stat, direction, color)
+  check_for_piped_visualize(NULL, NULL, color, endpoints)
   
   dots <- list(...)
   

--- a/R/shade_p_value.R
+++ b/R/shade_p_value.R
@@ -61,7 +61,7 @@ NULL
 shade_p_value <- function(obs_stat, direction,
                           color = "red2", fill = "pink", ...) {
   # argument checking
-  check_for_piped_visualize(obs_stat, direction, color, NULL)
+  check_for_piped_visualize(obs_stat, direction, color, fill)
   obs_stat <- check_obs_stat(obs_stat)
   check_shade_p_value_args(obs_stat, direction, color, fill)
   

--- a/R/shade_p_value.R
+++ b/R/shade_p_value.R
@@ -60,6 +60,8 @@ NULL
 #' @export
 shade_p_value <- function(obs_stat, direction,
                           color = "red2", fill = "pink", ...) {
+  # argument checking
+  check_for_piped_visualize(obs_stat, direction, color)
   obs_stat <- check_obs_stat(obs_stat)
   check_shade_p_value_args(obs_stat, direction, color, fill)
   

--- a/R/shade_p_value.R
+++ b/R/shade_p_value.R
@@ -61,7 +61,7 @@ NULL
 shade_p_value <- function(obs_stat, direction,
                           color = "red2", fill = "pink", ...) {
   # argument checking
-  check_for_piped_visualize(obs_stat, direction, color)
+  check_for_piped_visualize(obs_stat, direction, color, NULL)
   obs_stat <- check_obs_stat(obs_stat)
   check_shade_p_value_args(obs_stat, direction, color, fill)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -461,7 +461,7 @@ check_for_piped_visualize_ <- function(argument) {
     argument_name <- deparse(substitute(argument))
     
     # find what the type of the argument should actually be
-    if (argument_name == "obs_stat") {
+    if (argument_name %in% c("obs_stat", "endpoints")) {
       needed_type <- "numeric"
     } else if (argument_name == "direction") {
       needed_type <- "character"

--- a/R/utils.R
+++ b/R/utils.R
@@ -445,38 +445,21 @@ parse_type <- function(f_name) {
 
 # a function for checking arguments to functions that are added as layers
 # to visualize()d objects to make sure they weren't mistakenly piped
-check_for_piped_visualize <- function(obs_stat, direction, color, endpoints) {
-  # call the internal function 3 times since iteration doesn't preserve names
-  if (!is.null(obs_stat)) {check_for_piped_visualize_(obs_stat)}
-  if (!is.null(direction)) {check_for_piped_visualize_(direction)}
-  if (!is.null(color)) {check_for_piped_visualize_(color)}
-  if (!is.null(endpoints)) {check_for_piped_visualize_(endpoints)}
-}
-
-check_for_piped_visualize_ <- function(argument) {
-  # check for an input that was probably piped
-  if ("gg" %in% class(argument)) {
+check_for_piped_visualize <- function(...) {
+  
+  is_ggplot_output <- vapply(list(...), ggplot2::is.ggplot, logical(1))
+  
+  if (any(is_ggplot_output)) {
     
-    # extract the name of the argument
-    argument_name <- deparse(substitute(argument))
+    called_function <- sys.call(-1)[[1]]
     
-    # find what the type of the argument should actually be
-    if (argument_name %in% c("obs_stat", "endpoints")) {
-      needed_type <- "numeric"
-    } else if (argument_name == "direction") {
-      needed_type <- "character"
-    } else if (argument_name == "color") {
-      needed_type <- "color string"
-    }
-    
-    # grab the name of the function that the user actually called
-    called_function <- sys.call(-2)[[1]]
-    
-    # raise an error
-    stop_glue("It looks like the supplied `{argument_name}` argument is ",
-              "a plot rather than a `{needed_type}` object. ",
-              "Did you pipe the result of `visualize()` into ",
-              "`{called_function}` (using `%>%`) rather than adding ",
-              "the result of `{called_function}` as a layer with `+`?")
-    }
+    stop_glue(
+      "It looks like you piped the result of `visualize()` into ",
+      "`{called_function}()` (using `%>%`) rather than adding the result of ",
+      "`{called_function}()` as a layer with `+`. Consider changing",
+      "`%>%` to `+`."
+    )
+  }
+  
+  TRUE
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -445,11 +445,12 @@ parse_type <- function(f_name) {
 
 # a function for checking arguments to functions that are added as layers
 # to visualize()d objects to make sure they weren't mistakenly piped
-check_for_piped_visualize <- function(obs_stat, direction, color) {
+check_for_piped_visualize <- function(obs_stat, direction, color, endpoints) {
   # call the internal function 3 times since iteration doesn't preserve names
-  check_for_piped_visualize_(obs_stat)
-  check_for_piped_visualize_(direction)
-  check_for_piped_visualize_(color)
+  if (!is.null(obs_stat)) {check_for_piped_visualize_(obs_stat)}
+  if (!is.null(direction)) {check_for_piped_visualize_(direction)}
+  if (!is.null(color)) {check_for_piped_visualize_(color)}
+  if (!is.null(endpoints)) {check_for_piped_visualize_(endpoints)}
 }
 
 check_for_piped_visualize_ <- function(argument) {

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -76,6 +76,14 @@ test_that("shade_confidence_interval throws errors and warnings", {
     iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
     "\\`shade_confidence_interval\\(\\)\\` as a layer"
   )
+  expect_error(
+    iris_viz_sim %>% shade_ci(c(-1, 1)), 
+    "\\`shade_ci\\(\\)\\` as a layer"
+  )
+  expect_error(
+    iris_viz_sim %>% shade_ci(endpoints = c(-1, 1)), 
+    "\\`shade_ci\\(\\)\\` as a layer"
+  )
 })
 
 

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -70,11 +70,11 @@ test_that("shade_confidence_interval throws errors and warnings", {
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(c(-1, 1)), 
-    "\\`shade_confidence_interval()\\` as a layer"
+    "\\`shade_confidence_interval\\(\\)\\` as a layer"
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
-    "\\`shade_confidence_interval()\\` as a layer"
+    "\\`shade_confidence_interval\\(\\)\\` as a layer"
   )
 })
 

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -70,11 +70,11 @@ test_that("shade_confidence_interval throws errors and warnings", {
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(c(-1, 1)), 
-    "is a plot"
+    "adding the result"
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
-    "is a plot"
+    "adding the result"
   )
 })
 

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -70,11 +70,11 @@ test_that("shade_confidence_interval throws errors and warnings", {
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(c(-1, 1)), 
-    "adding the result"
+    "`shade_confidence_interval()` as a layer"
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
-    "adding the result"
+    "`shade_confidence_interval()` as a layer"
   )
 })
 

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -70,11 +70,11 @@ test_that("shade_confidence_interval throws errors and warnings", {
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(c(-1, 1)), 
-    "`shade_confidence_interval()` as a layer"
+    "\\`shade_confidence_interval()\\` as a layer"
   )
   expect_error(
     iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
-    "`shade_confidence_interval()` as a layer"
+    "\\`shade_confidence_interval()\\` as a layer"
   )
 })
 

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -68,6 +68,14 @@ test_that("shade_confidence_interval throws errors and warnings", {
     iris_viz_sim + shade_confidence_interval(c(-1, 1), fill = "x"),
     "color"
   )
+  expect_error(
+    iris_viz_sim %>% shade_confidence_interval(c(-1, 1)), 
+    "is a plot"
+  )
+  expect_error(
+    iris_viz_sim %>% shade_confidence_interval(endpoints = c(-1, 1)), 
+    "is a plot"
+  )
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -93,12 +93,12 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim + shade_p_value(1, "right", color = "x"), "color")
   expect_error(iris_viz_sim + shade_p_value(1, "right", fill = "x"), "color")
   expect_error(iris_viz_sim %>% shade_p_value(1, "right"), 
-               "`shade_p_value()` as a layer")
+               "\\`shade_p_value()\\` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1), 
-               "`shade_p_value()` as a layer")
+               "\\`shade_p_value()\\` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
                                               direction = "right"), 
-               "`shade_p_value()` as a layer")
+               "\\`shade_p_value()\\` as a layer")
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -93,12 +93,12 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim + shade_p_value(1, "right", color = "x"), "color")
   expect_error(iris_viz_sim + shade_p_value(1, "right", fill = "x"), "color")
   expect_error(iris_viz_sim %>% shade_p_value(1, "right"), 
-               "adding the result")
+               "`shade_p_value()` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1), 
-               "adding the result")
+               "`shade_p_value()` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
                                               direction = "right"), 
-               "adding the result")
+               "`shade_p_value()` as a layer")
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -93,12 +93,12 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim + shade_p_value(1, "right", color = "x"), "color")
   expect_error(iris_viz_sim + shade_p_value(1, "right", fill = "x"), "color")
   expect_error(iris_viz_sim %>% shade_p_value(1, "right"), 
-               "is a plot")
+               "adding the result")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1), 
-               "is a plot")
+               "adding the result")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
                                               direction = "right"), 
-               "is a plot")
+               "adding the result")
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -99,6 +99,14 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
                                               direction = "right"), 
                "\\`shade_p_value\\(\\)\\` as a layer")
+  expect_error(iris_viz_sim %>% shade_pvalue(1, "right"), 
+               "\\`shade_pvalue\\(\\)\\` as a layer")
+  expect_error(iris_viz_sim %>% shade_pvalue(obs_stat = 1), 
+               "\\`shade_pvalue\\(\\)\\` as a layer")
+  expect_error(iris_viz_sim %>% shade_pvalue(obs_stat = 1, 
+                                              direction = "right"), 
+               "\\`shade_pvalue\\(\\)\\` as a layer")
+  
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -92,6 +92,13 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim + shade_p_value(1, 1), "character")
   expect_error(iris_viz_sim + shade_p_value(1, "right", color = "x"), "color")
   expect_error(iris_viz_sim + shade_p_value(1, "right", fill = "x"), "color")
+  expect_error(iris_viz_sim %>% shade_p_value(1, "right"), 
+               "is a plot")
+  expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1), 
+               "is a plot")
+  expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
+                                              direction = "right"), 
+               "is a plot")
 })
 
 

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -93,12 +93,12 @@ test_that("shade_p_value throws errors", {
   expect_error(iris_viz_sim + shade_p_value(1, "right", color = "x"), "color")
   expect_error(iris_viz_sim + shade_p_value(1, "right", fill = "x"), "color")
   expect_error(iris_viz_sim %>% shade_p_value(1, "right"), 
-               "\\`shade_p_value()\\` as a layer")
+               "\\`shade_p_value\\(\\)\\` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1), 
-               "\\`shade_p_value()\\` as a layer")
+               "\\`shade_p_value\\(\\)\\` as a layer")
   expect_error(iris_viz_sim %>% shade_p_value(obs_stat = 1, 
                                               direction = "right"), 
-               "\\`shade_p_value()\\` as a layer")
+               "\\`shade_p_value\\(\\)\\` as a layer")
 })
 
 


### PR DESCRIPTION
Hi all!

A PR to address an error message that often tripped students up last semester—when piping after visualize, 

``` r

library(infer)

gss %>% 
  specify(response = hours)  %>% 
  hypothesize(null = "point", mu = 40) %>% 
  generate(reps = 100, type = "bootstrap") %>% 
  calculate(stat = "mean") %>%
  visualize() %>%
  shade_p_value(obs_stat = 1, direction = "both")
#> Warning: Removed 1244 rows containing missing values.
#> Error: `color` must be 'color string', not 'list'.
```

<sup>Created on 2020-01-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Before running the current argument checking messages, `shade_p_value` and `shade_confidence_interval` will now check if a plot object was supplied as an argument, and raise an error if so. The new error for the code above would be:

```{r}
#> Warning: Removed 1244 rows containing missing values.
#> Error: It looks like the supplied `color` argument is a plot 
rather than a `color string` object. Did you pipe the result of 
`visualize()` into `shade_p_value` (using `%>%`) rather than 
adding the result of `shade_p_value` as a layer with `+`? 
```

The error will fill in the appropriate values for the name of the argument that was given the plot object, the type of argument needed, and the function the user actually called.