### PR TITLE
implement stat = "ratio of props" and "odds ratio" (#285)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Increase coverage of theoretical methods in documentation (#278, #280)
 - Drop missing values and reduce size of `gss` dataset used in examples (#282)
 - Fix formatting of lifecycle badges (#283)
+- Add `stat = "ratio of props"` and `stat = "odds ratio"` to `calculate` (#285)
 
 # infer 0.5.1
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -116,8 +116,8 @@ calculate <- function(x,
   )) {
     if (!is.null(order)) {
       warning_glue(
-        "Statistic is not based on a difference; the `order` argument ",
-        "is ignored. Check `?calculate` for details."
+        "Statistic is not based on a difference or ratio; the `order` argument",
+        " will be ignored. Check `?calculate` for details."
       )
     }
   }

--- a/R/infer.R
+++ b/R/infer.R
@@ -21,7 +21,8 @@ if (getRversion() >= "2.15.1") {
       "prop", "stat", "value", "x", "y", "..density..", "statistic", ".",
       "parameter", "p.value", "xmin", "x_min", "xmax", "x_max", "density",
       "denom", "diff_prop", "group_num", "n1", "n2", "num_suc", "p_hat",
-      "total_suc", "explan", "probs", "conf.low", "conf.high"
+      "total_suc", "explan", "probs", "conf.low", "conf.high", "prop_1", 
+      "prop_2"
     )
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,17 +129,17 @@ check_order <- function(x, explanatory_variable, order) {
     )
   }
   if (is.null(order)) {
-    # Default to subtracting the first (alphabetically) level from the second,
-    # unless the explanatory variable is a factor (in which case order is 
-    # preserved); raise a warning if this was done implicitly.
+    # Default to subtracting/dividing the first (alphabetically) level by the 
+    # second, unless the explanatory variable is a factor (in which case order 
+    # is preserved); raise a warning if this was done implicitly.
     order <- as.character(unique_ex)
     warning_glue(
-      "The statistic is based on a difference; by default, the ",
-      "explanatory variable has been subtracted in the order ", 
-      "\"{unique_ex[1]}\" - \"{unique_ex[2]}\". To specify the ",
-      "order yourself, provide `order = c(\"{unique_ex[1]}\", ",
-      "\"{unique_ex[2]}\")` (to subtract in the order ",
-      "\"{unique_ex[1]}\" - \"{unique_ex[2]}\") to the calculate() function."
+      "The statistic is based on a difference or ratio; by default, for ",
+      "difference-based statistics, the explanatory variable is subtracted ",
+      "in the order \"{unique_ex[1]}\" - \"{unique_ex[2]}\", or divided in ", 
+      "the order \"{unique_ex[1]}\" / \"{unique_ex[2]}\" for ratio-based ",
+      "statistics. To specify this order yourself, supply `order = ",
+      "c(\"{unique_ex[1]}\", \"{unique_ex[2]}\")` to the calculate() function."
     )
   } else {
     if (xor(is.na(order[1]), is.na(order[2]))) {
@@ -169,7 +169,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
     !stat %in% c(
       "mean", "median", "sum", "sd", "prop", "count", "diff in means",
       "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation",
-      "t", "z"
+      "t", "z", "ratio of props"
     )
   ) {
     stop_glue(
@@ -194,7 +194,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
     }
   }
 
-  if (stat %in% c("diff in props", "Chisq")) {
+  if (stat %in% c("diff in props", "ratio of props", "Chisq")) {
     if (has_explanatory(x) && !is.factor(response_variable(x))) {
       stop_glue(
         'The response variable of `{attr(x, "response")}` is not appropriate\n',
@@ -219,7 +219,8 @@ check_for_numeric_stat <- function(x, stat) {
 }
 
 check_for_factor_stat <- function(x, stat, explanatory_variable) {
-  if (stat %in% c("diff in means", "diff in medians", "diff in props", "F")) {
+  if (stat %in% c("diff in means", "diff in medians", "diff in props", 
+                  "F", "ratio of props")) {
     if (!is.factor(explanatory_variable)) {
       stop_glue(
         'The explanatory variable of `{attr(x, "explanatory")}` is not ',

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,7 +169,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
     !stat %in% c(
       "mean", "median", "sum", "sd", "prop", "count", "diff in means",
       "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation",
-      "t", "z", "ratio of props"
+      "t", "z", "ratio of props", "odds ratio"
     )
   ) {
     stop_glue(
@@ -194,7 +194,7 @@ check_args_and_attr <- function(x, explanatory_variable, response_variable,
     }
   }
 
-  if (stat %in% c("diff in props", "ratio of props", "Chisq")) {
+  if (stat %in% c("diff in props", "ratio of props", "Chisq", "odds ratio")) {
     if (has_explanatory(x) && !is.factor(response_variable(x))) {
       stop_glue(
         'The response variable of `{attr(x, "response")}` is not appropriate\n',
@@ -220,7 +220,7 @@ check_for_numeric_stat <- function(x, stat) {
 
 check_for_factor_stat <- function(x, stat, explanatory_variable) {
   if (stat %in% c("diff in means", "diff in medians", "diff in props", 
-                  "F", "ratio of props")) {
+                  "F", "ratio of props", "odds ratio")) {
     if (!is.factor(explanatory_variable)) {
       stop_glue(
         'The explanatory variable of `{attr(x, "explanatory")}` is not ',

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,8 +124,8 @@ check_order <- function(x, explanatory_variable, order) {
   unique_ex <- sort(unique(explanatory_variable))
   if (length(unique_ex) != 2) {
     stop_glue(
-      "Statistic is based on a difference; the explanatory variable should ",
-      "have two levels."
+      "Statistic is based on a difference or ratio; the explanatory variable", 
+      "should have two levels."
     )
   }
   if (is.null(order)) {

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -8,7 +8,7 @@ calculate(
   x,
   stat = c("mean", "median", "sum", "sd", "prop", "count", "diff in means",
     "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation", "t", "z",
-    "ratio of props"),
+    "ratio of props", "odds ratio"),
   order = NULL,
   ...
 )

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -7,7 +7,8 @@
 calculate(
   x,
   stat = c("mean", "median", "sum", "sd", "prop", "count", "diff in means",
-    "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation", "t", "z"),
+    "diff in medians", "diff in props", "Chisq", "F", "slope", "correlation", "t", "z",
+    "ratio of props"),
   order = NULL,
   ...
 )
@@ -19,7 +20,7 @@ output from \code{\link[=hypothesize]{hypothesize()}} piped in to here for theor
 \item{stat}{A string giving the type of the statistic to calculate. Current
 options include \code{"mean"}, \code{"median"}, \code{"sum"}, \code{"sd"}, \code{"prop"}, \code{"count"},
 \code{"diff in means"}, \code{"diff in medians"}, \code{"diff in props"}, \code{"Chisq"},
-\code{"F"}, \code{"t"}, \code{"z"}, \code{"slope"}, and \code{"correlation"}.}
+\code{"F"}, \code{"t"}, \code{"z"}, \code{"ratio of props"}, \code{"slope"}, and \code{"correlation"}.}
 
 \item{order}{A string vector of specifying the order in which the levels of
 the explanatory variable should be ordered for subtraction, where \code{order = c("first", "second")} means \code{("first" - "second")} Needed for inference on

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -271,7 +271,7 @@ test_that("`order` is working", {
   )
   # order not given
   expect_warning(calculate(gen_iris11, stat = "diff in means"),
-                 "by default, the explanatory variable has been subtracted")
+                 "The statistic is based on a difference or ratio")
 })
 
 gen_iris12 <- iris %>%

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -105,6 +105,8 @@ test_that("response variable is a factor (two var problems)", {
     hypothesize(null = "independence") %>%
     generate(reps = 10, type = "permute")
   expect_error(calculate(gen_iris4, stat = "diff in props"))
+  expect_error(calculate(gen_iris4, stat = "ratio of props"))
+  expect_error(calculate(gen_iris4, stat = "odds ratio"))
 
   expect_error(calculate(gen_iris4, stat = "t"))
 
@@ -121,6 +123,12 @@ test_that("response variable is a factor (two var problems)", {
     generate(reps = 10, type = "permute")
   expect_silent(
     calculate(gen_iris4a, stat = "diff in props", order = c("large", "small"))
+  )
+  expect_silent(
+    calculate(gen_iris4a, stat = "ratio of props", order = c("large", "small"))
+  )
+  expect_silent(
+    calculate(gen_iris4a, stat = "odds ratio", order = c("large", "small"))
   )
   expect_silent(
     calculate(gen_iris4a, stat = "z", order = c("large", "small"))

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -503,34 +503,29 @@ gss_biased <- gss %>%
 gss_tbl <- table(gss_biased$sex, gss_biased$college)
 
 test_that("calc_impl.odds_ratio works", {
-  
   base_odds_ratio <- {(gss_tbl[1,1] * gss_tbl[2,2]) / 
     (gss_tbl[1,2] * gss_tbl[2,1])}
   
-  expect_equal({
+  expect_equal(
     gss_biased %>% 
       specify(college ~ sex, success = "degree") %>%
       calculate(stat = "odds ratio", order = c("female", "male")) %>%
-      dplyr::pull()
-  },
-                expected = base_odds_ratio,
-                tolerance = .001)
-  
+      dplyr::pull(),
+    expected = base_odds_ratio,
+    tolerance = .001)
 })
 
 test_that("calc_impl.ratio_of_props works", {
-  
   base_ratio_of_props <- {(gss_tbl[1,2] / sum(gss_tbl[1,])) / 
       (gss_tbl[2,2] / sum(gss_tbl[2,]))}
   
-  expect_equal({
+  expect_equal(
     gss_biased %>% 
       specify(college ~ sex, success = "degree") %>%
       calculate(stat = "ratio of props", order = c("male", "female")) %>%
-      dplyr::pull()
-  },
-                expected = base_ratio_of_props,
-                tolerance = .001)
+      dplyr::pull(),
+    expected = base_ratio_of_props,
+    tolerance = .001)
   
 })
 

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -495,3 +495,42 @@ test_that("calc_impl.count works", {
     gen_iris12 %>% dplyr::summarise(stat = sum(Sepal.Length.Group == ">5"))
   )
 })
+
+
+gss_biased <- gss %>% 
+  dplyr::filter(!(sex == "male" & college == "no degree" & age < 40))
+
+gss_tbl <- table(gss_biased$sex, gss_biased$college)
+
+test_that("calc_impl.odds_ratio works", {
+  
+  base_odds_ratio <- {(gss_tbl[1,1] * gss_tbl[2,2]) / 
+    (gss_tbl[1,2] * gss_tbl[2,1])}
+  
+  expect_equal({
+    gss_biased %>% 
+      specify(college ~ sex, success = "degree") %>%
+      calculate(stat = "odds ratio", order = c("female", "male")) %>%
+      dplyr::pull()
+  },
+                expected = base_odds_ratio,
+                tolerance = .001)
+  
+})
+
+test_that("calc_impl.ratio_of_props works", {
+  
+  base_ratio_of_props <- {(gss_tbl[1,2] / sum(gss_tbl[1,])) / 
+      (gss_tbl[2,2] / sum(gss_tbl[2,]))}
+  
+  expect_equal({
+    gss_biased %>% 
+      specify(college ~ sex, success = "degree") %>%
+      calculate(stat = "ratio of props", order = c("male", "female")) %>%
+      dplyr::pull()
+  },
+                expected = base_ratio_of_props,
+                tolerance = .001)
+  
+})
+

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -233,6 +233,8 @@ Not yet implemented.
 
 ### Two categorical (2 level) variables
 
+The `infer` package provides several statistics to work with data of this type. One of them is the statistic for difference in proportions. 
+
 Calculating the observed statistic,
 
 ```{r}
@@ -263,6 +265,74 @@ Calculating the p-value from the null distribution and observed statistic,
 ```{r}
 null_distn %>%
   get_p_value(obs_stat = d_hat, direction = "two_sided")
+```
+
+`infer` also provides functionality to calculate ratios of proportions. The workflow looks similar to that for `diff in props`.
+
+Calculating the observed statistic,
+
+```{r}
+r_hat <- gss %>% 
+  specify(college ~ sex, success = "no degree") %>%
+  calculate(stat = "ratio of props", order = c("female", "male"))
+```
+
+Then, generating the null distribution,
+
+```{r}
+null_distn <- gss %>%
+  specify(college ~ sex, success = "no degree") %>%
+  hypothesize(null = "independence") %>% 
+  generate(reps = 1000) %>% 
+  calculate(stat = "ratio of props", order = c("female", "male"))
+```
+
+Visualizing the observed statistic alongside the null distribution,
+
+```{r}
+visualize(null_distn) +
+  shade_p_value(obs_stat = r_hat, direction = "two_sided")
+```
+
+Calculating the p-value from the null distribution and observed statistic,
+
+```{r}
+null_distn %>%
+  get_p_value(obs_stat = r_hat, direction = "two_sided")
+```
+
+In addition, the package provides functionality to calculate odds ratios. The workflow also looks similar to that for `diff in props`.
+
+Calculating the observed statistic,
+
+```{r}
+or_hat <- gss %>% 
+  specify(college ~ sex, success = "no degree") %>%
+  calculate(stat = "odds ratio", order = c("female", "male"))
+```
+
+Then, generating the null distribution,
+
+```{r}
+null_distn <- gss %>%
+  specify(college ~ sex, success = "no degree") %>%
+  hypothesize(null = "independence") %>% 
+  generate(reps = 1000) %>% 
+  calculate(stat = "odds ratio", order = c("female", "male"))
+```
+
+Visualizing the observed statistic alongside the null distribution,
+
+```{r}
+visualize(null_distn) +
+  shade_p_value(obs_stat = or_hat, direction = "two_sided")
+```
+
+Calculating the p-value from the null distribution and observed statistic,
+
+```{r}
+null_distn %>%
+  get_p_value(obs_stat = or_hat, direction = "two_sided")
 ```
 
 ### Two categorical (2 level) variables (z)


### PR DESCRIPTION
Hi there!

This pull request adds `stat = "ratio of props"` and `stat = "odds ratio"` as options to `calculate` in response to issue #285. I've added unit testing and documentation (in `observed_stat_examples.Rmd`) for both of them as well!

I believe I've covered all bases in `.implement_new_methods.md`, but let me know if I'm missing any functionality for these two stats. 