### PR TITLE
address dplyr 1.0.0 breaking changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Updates to `visualize()` for compatibility with `ggplot2` v3.3.0 (#289)
 - Fix error when bootstrapping with small samples and raise warnings/errors 
 when appropriate (#239, #244, #291)
+- Fix unit test failures resulting from breaking changes in `dplyr` v1.0.0
 
 # infer 0.5.1
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -447,7 +447,7 @@ calc_impl.z <- function(type, x, order, ...) {
     aggregated <- x %>%
       dplyr::group_by(replicate, explan) %>%
       dplyr::summarize(
-        group_num = n(),
+        group_num = dplyr::n(),
         prop = mean(rlang::eval_tidy(col) == rlang::eval_tidy(success)),
         num_suc = sum(rlang::eval_tidy(col) == rlang::eval_tidy(success))
       )

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -224,7 +224,7 @@ test_that("chi-square matches chisq.test value", {
       stats::chisq.test(table(.$Species))
     )) %>%
     dplyr::select(replicate, stat = statistic)
-  expect_equal(infer_way, trad_way)
+  expect_equivalent(infer_way, trad_way)
 
   gen_iris9a <- iris %>%
     specify(Species ~ NULL) %>%
@@ -241,7 +241,7 @@ test_that("chi-square matches chisq.test value", {
       stats::chisq.test(table(.$Species), p = c(0.8, 0.1, 0.1))
     )) %>%
     dplyr::select(replicate, stat = statistic)
-  expect_equal(infer_way, trad_way)
+  expect_equivalent(infer_way, trad_way)
 })
 
 test_that("`order` is working", {
@@ -490,7 +490,7 @@ test_that("calc_impl.count works", {
     sum(iris_tbl$Sepal.Length.Group == ">5")
   )
 
-  expect_equal(
+  expect_equivalent(
     gen_iris12 %>% calculate(stat = "count"),
     gen_iris12 %>% dplyr::summarise(stat = sum(Sepal.Length.Group == ">5"))
   )


### PR DESCRIPTION
Some small changes to address the build failures resulting from breaking changes in the version of `dplyr` to be submitted to CRAN in the next couple weeks.

From the `dplyr` [release notes](https://github.com/tidyverse/dplyr/blob/master/NEWS.md): 

* “n() and row_number() can no longer be called directly when dplyr is not loaded,” hence the transition of an `n()` to `dplyr::n()` in `calculate`.

* “expect_equal() uses all.equal() internally.” I’ve transitioned a few `expect_equal`s to `expect_equivalent`s in unit tests so that dataframes with matching entries will pass even if `infer` appended attributes are present in one dataframe but not in another.

If this looks good, once this is merged, I'll start prepping for CRAN release!