### PR TITLE
Deal with `generate()` in case of "simulate" and 'x' response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Fix error when bootstrapping with small samples and raise warnings/errors 
 when appropriate (#239, #244, #291)
 - Fix unit test failures resulting from breaking changes in `dplyr` v1.0.0
+- Fix error in `generate()` when response variable is named `x` (#299)
 
 # infer 0.5.1
 

--- a/R/generate.R
+++ b/R/generate.R
@@ -211,10 +211,13 @@ simulate <- function(x, reps = 1, ...) {
     sample(fct_levels, size = nrow(x), replace = TRUE, prob = format_params(x)),
     simplify = FALSE
   ))
-
+  
+  # Precomputing `nrow(x)` is needed because it can be misinterpeted inside
+  # `tibble()` in case `attr(x, "response")` is also `x` (see #299)
+  x_nrow <- nrow(x)
   rep_tbl <- tibble::tibble(
     !!attr(x, "response") := as.factor(col_simmed),
-    replicate = as.factor(rep(1:reps, rep(nrow(x), reps)))
+    replicate = as.factor(rep(1:reps, rep(x_nrow, reps)))
   )
 
   rep_tbl <- copy_attrs(to = rep_tbl, from = x)

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -277,3 +277,13 @@ test_that("generate() handles `NULL` value of `type`", {
     fixed = TRUE
   )
 })
+
+test_that("generate() handles `x` response in case of 'simulate' (#299)", {
+  expect_named(
+    data.frame(x = factor(rbinom(100, size = 1, prob = .5))) %>%
+      specify(response = x, success = "1") %>%
+      hypothesize(null = "point", p = .5) %>%
+      generate(reps = 100, type = "simulate"),
+    c("x", "replicate")
+  )
+})


### PR DESCRIPTION
Fixes #299.