### PR TITLE
using expect_equivalent() instead of expect_equal()

### DIFF
--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -216,7 +216,7 @@ test_that("chi-square matches chisq.test value", {
       stats::chisq.test(table(.$Species))
     )) %>%
     dplyr::select(replicate, stat = statistic)
-  expect_equal(infer_way, trad_way)
+  expect_equivalent(infer_way, trad_way)
 
   gen_iris9a <- iris %>%
     specify(Species ~ NULL) %>%
@@ -233,7 +233,7 @@ test_that("chi-square matches chisq.test value", {
       stats::chisq.test(table(.$Species), p = c(0.8, 0.1, 0.1))
     )) %>%
     dplyr::select(replicate, stat = statistic)
-  expect_equal(infer_way, trad_way)
+  expect_equivalent(infer_way, trad_way)
 })
 
 test_that("`order` is working", {
@@ -470,7 +470,7 @@ test_that("calc_impl.count works", {
     sum(iris_tbl$Sepal.Length.Group == ">5")
   )
 
-  expect_equal(
+  expect_equivalent(
     gen_iris12 %>% calculate(stat = "count"),
     gen_iris12 %>% dplyr::summarise(stat = sum(Sepal.Length.Group == ">5"))
   )


### PR DESCRIPTION
this helps with dplyr 1.0.0

however I'm still getting locally a bunch of these: 

```
x |  20 15 8   | shade_p_value [8.8 s]
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
test-shade_p_value.R:9: failure: shade_p_value works
Figures don't match: pval-sim-right.svg


test-shade_p_value.R:12: failure: shade_p_value works
Figures don't match: pval-sim-left.svg


test-shade_p_value.R:13: failure: shade_p_value works
Figures don't match: pval-sim-both.svg


test-shade_p_value.R:21: warning: shade_p_value works
`mapping` is not used by stat_function()

test-shade_p_value.R:21: warning: shade_p_value works
`data` is not used by stat_function()

test-shade_p_value.R:21: failure: shade_p_value works
Figures don't match: pval-theor-right.svg


test-shade_p_value.R:24: warning: shade_p_value works
`mapping` is not used by stat_function()

test-shade_p_value.R:24: warning: shade_p_value works
`data` is not used by stat_function()

test-shade_p_value.R:24: failure: shade_p_value works
Figures don't match: pval-theor-left.svg


test-shade_p_value.R:27: warning: shade_p_value works
`mapping` is not used by stat_function()

test-shade_p_value.R:27: warning: shade_p_value works
`data` is not used by stat_function()

test-shade_p_value.R:27: warning: shade_p_value works
`mapping` is not used by stat_function()

test-shade_p_value.R:27: warning: shade_p_value works
`data` is not used by stat_function()

test-shade_p_value.R:27: failure: shade_p_value works
Figures don't match: pval-theor-both.svg


test-shade_p_value.R:39: failure: shade_p_value works
Figures don't match: pval-both-right.svg


test-shade_p_value.R:42: failure: shade_p_value works
Figures don't match: pval-both-left.svg


test-shade_p_value.R:45: failure: shade_p_value works
Figures don't match: pval-both-both.svg


test-shade_p_value.R:58: failure: shade_p_value accepts synonyms for 'direction'
Figures don't match: pval-direction-right.svg


test-shade_p_value.R:61: failure: shade_p_value accepts synonyms for 'direction'
Figures don't match: pval-direction-left.svg


test-shade_p_value.R:64: failure: shade_p_value accepts synonyms for 'direction'
Figures don't match: pval-direction-both.svg


test-shade_p_value.R:70: failure: shade_p_value uses extra aesthetic
Figures don't match: pval-extra-aes-1.svg


test-shade_p_value.R:74: failure: shade_p_value uses extra aesthetic
Figures don't match: pval-extra-aes-2.svg


test-shade_p_value.R:78: failure: shade_p_value uses extra aesthetic
Figures don't match: pval-extra-aes-3.svg

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

══ Terminating early ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Too many failures
```