### PR TITLE
fix order arg in t wrappers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ when appropriate (#239, #244, #291)
 - Fix error in `generate()` when response variable is named `x` (#299)
 - Add `two-sided` and `two sided` as aliases for `two_sided` for the 
 `direction` argument in `get_p_value()` and `shade_p_value()` (#302)
+- Fix `t_test()` and `t_stat()` ignoring the `order` argument (#310)
 
 # infer 0.5.1
 

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -84,6 +84,7 @@ t_test <- function(x, formula,
     #                                                       ordered = TRUE)
     # }
     order <- check_order(x, explanatory_variable(x), order, in_calculate = FALSE)
+    x <- reorder_explanatory(x, order)
     prelim <- stats::t.test(formula = as.formula(paste0(attr(x, "response"),
                                                         " ~ ",
                                                         attr(x, "explanatory"))),
@@ -196,6 +197,7 @@ t_stat <- function(x, formula,
     #                                                       ordered = TRUE)
     # }
     order <- check_order(x, explanatory_variable(x), order, in_calculate = FALSE)
+    x <- reorder_explanatory(x, order)
     prelim <- stats::t.test(formula = as.formula(paste0(attr(x, "response"),
                                                         " ~ ",
                                                         attr(x, "explanatory"))),

--- a/tests/testthat/test-visualize.R
+++ b/tests/testthat/test-visualize.R
@@ -39,7 +39,7 @@ obs_diff_mean <- iris_tbl %>%
   pull()
 
 obs_t <- iris_tbl %>%
-  t_stat(Sepal.Width ~ Sepal.Length.Group, order = c(">5", "<=5"))
+  t_stat(Sepal.Width ~ Sepal.Length.Group, order = c("<=5", ">5"))
 
 obs_F <- anova(
     aov(formula = Sepal.Width ~ Species, data = iris_tbl)

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -32,6 +32,13 @@ test_that("t_test works", {
   expect_equal(new_way, new_way_alt, tolerance = 1e-5)
   expect_equal(new_way, old_way, tolerance = 1e-5)
   
+  # check that the order argument changes output
+  new_way2 <- t_test(iris2, 
+                    Sepal.Width ~ Species, 
+                    order = c("virginica", "versicolor"))  
+  expect_equal(new_way[["lower_ci"]], -new_way2[["upper_ci"]])
+  expect_equal(new_way[["statistic"]], -new_way2[["statistic"]])
+  
   # One Sample
   new_way <- iris2 %>%
     t_test(Sepal.Width ~ NULL, mu = 0)


### PR DESCRIPTION
This PR fixes #310—the `t_test()` and `t_stat()` wrappers were ignoring the `order` argument. I’ve just dropped in calls to the same `reorder_explanatory()` from `calc_impl.t()` into the `t_test()` and `t_stat()` definitions, and added unit testing to now check to make sure the two are sensitive to the `order` argument from here on out!

``` r
library(infer)

iris %>%
  dplyr::filter(Species != "virginica") %>%
  t_test(Petal.Length ~ Species, order = c("setosa", "versicolor"))
#> # A tibble: 1 x 6
#>   statistic  t_df  p_value alternative lower_ci upper_ci
#>       <dbl> <dbl>    <dbl> <chr>          <dbl>    <dbl>
#> 1     -39.5  62.1 9.93e-46 two.sided      -2.94    -2.66

iris %>%
  dplyr::filter(Species != "virginica") %>%
  t_test(Petal.Length ~ Species, order = c("versicolor", "setosa"))
#> # A tibble: 1 x 6
#>   statistic  t_df  p_value alternative lower_ci upper_ci
#>       <dbl> <dbl>    <dbl> <chr>          <dbl>    <dbl>
#> 1      39.5  62.1 9.93e-46 two.sided       2.66     2.94
```

<sup>Created on 2020-05-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>