### PR TITLE
Update `get_confidence_interval()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: infer
 Type: Package
 Title: Tidy Statistical Inference
-Version: 0.5.2
+Version: 0.5.2.9000
 Authors@R: c(
     person("Andrew", "Bray", email = "abray@reed.edu", role = c("aut", "cre")),
     person("Chester", "Ismay", email = "chester.ismay@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # infer (development version)
 
+## Breaking changes
+
+- `get_confidence_interval()` now uses consistent column names ('lower_ci' and 'upper_ci') in output (#317).
+
+## New functionality
+
+- Implement new type `"bias-corrected"` for `get_confidence_interval()` to produce bias-corrected confidence intervals (#237, #318). Thanks to @davidbaniadam for initial implementation.
+
+## Other
+
 # infer 0.5.2
 
 - Warn the user when a p-value of 0 is reported (#257, #273)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# infer (development version)
+
 # infer 0.5.2
 
 - Warn the user when a p-value of 0 is reported (#257, #273)

--- a/R/get_confidence_interval.R
+++ b/R/get_confidence_interval.R
@@ -19,8 +19,8 @@
 #' @param point_estimate A numeric value or a 1x1 data frame set to `NULL` by
 #'   default. Needed to be provided if `type` is `"se"` or `"bias-corrected"`.
 #'
-#' @return A 1 x 2 tibble with values corresponding to lower and upper values in
-#'   the confidence interval.
+#' @return A 1 x 2 tibble with 'lower_ci' and 'upper_ci' columns. Values
+#'   correspond to lower and upper bounds of the confidence interval.
 #'
 #' @section Aliases:
 #' `get_ci()` is an alias of `get_confidence_interval()`.
@@ -89,7 +89,7 @@ get_ci <- function(x, level = 0.95, type = "percentile",
 ci_percentile <- function(x, level) {
   ci_vec <- stats::quantile(x[["stat"]], probs = (1 + c(-level, level)) / 2)
   
-  tibble::as_tibble(as.list(ci_vec))
+  make_ci_df(ci_vec)
 }
 
 ci_se <- function(x, level, point_estimate) {
@@ -98,7 +98,7 @@ ci_se <- function(x, level, point_estimate) {
   multiplier <- stats::qnorm((1 + level) / 2)
   ci_vec <- point_estimate + c(-multiplier, multiplier) * stats::sd(x[["stat"]])
   
-  tibble::tibble(lower = ci_vec[[1]], upper = ci_vec[[2]])
+  make_ci_df(ci_vec)
 }
 
 ci_bias_corrected <- function(x, level, point_estimate) {
@@ -112,7 +112,7 @@ ci_bias_corrected <- function(x, level, point_estimate) {
   
   ci_vec <- stats::quantile(x[["stat"]], probs = new_probs)
   
-  tibble::tibble(lower = ci_vec[[1]], upper = ci_vec[[2]])
+  make_ci_df(ci_vec)
 }
 
 check_ci_args <- function(x, level, type, point_estimate){
@@ -145,3 +145,6 @@ check_ci_args <- function(x, level, type, point_estimate){
   }
 }
 
+make_ci_df <- function(ci_vec) {
+  tibble::tibble(lower_ci = ci_vec[[1]], upper_ci = ci_vec[[2]])
+}

--- a/R/get_confidence_interval.R
+++ b/R/get_confidence_interval.R
@@ -64,6 +64,11 @@ get_confidence_interval <- function(x, level = 0.95, type = "percentile",
                                     point_estimate = NULL) {
   check_ci_args(x, level, type, point_estimate)
   
+  # Inform if no `level` was explicitly supplied
+  if (!("level" %in% rlang::call_args_names(match.call()))) {
+    message_glue("Using `level = {level}` to compute confidence interval.")
+  }
+  
   switch(
     type,
     percentile = ci_percentile(x, level),

--- a/R/get_confidence_interval.R
+++ b/R/get_confidence_interval.R
@@ -20,6 +20,7 @@
 #'
 #' @return A 1 x 2 tibble with values corresponding to lower and upper values in
 #'   the confidence interval.
+#'
 #' @section Aliases:
 #' `get_ci()` is an alias of `get_confidence_interval()`.
 #' `conf_int()` is a deprecated alias of `get_confidence_interval()`.
@@ -43,11 +44,13 @@
 #'   # finding the null distribution
 #'   calculate(stat = "mean") %>%
 #    # calculate the confidence interval around the point estimate
-#'   get_confidence_interval(point_estimate = point_estimate,
-#'                           # at the 95% confidence level
-#'                           level = .95,
-#'                           # using the standard error method
-#'                           type = "se")
+#'   get_confidence_interval(
+#'     point_estimate = point_estimate,
+#'     # at the 95% confidence level
+#'     level = 0.95,
+#'     # using the standard error method
+#'     type = "se"
+#'   )
 #'   
 #' # More in-depth explanation of how to use the infer package
 #' \dontrun{
@@ -57,59 +60,67 @@
 #' @name get_confidence_interval
 #' @export
 get_confidence_interval <- function(x, level = 0.95, type = "percentile",
-  point_estimate = NULL){
-
+                                    point_estimate = NULL) {
   check_ci_args(x, level, type, point_estimate)
 
-  if(type == "percentile") {
-    ci_vec <- stats::quantile(x[["stat"]],
-      probs = c((1 - level) / 2, level + (1 - level) / 2))
-
+  if (type == "percentile") {
+    ci_vec <- stats::quantile(
+      x[["stat"]],
+      probs = c((1 - level) / 2, level + (1 - level) / 2)
+    )
+    
     ci <- tibble::tibble(ci_vec[1], ci_vec[2])
     names(ci) <- names(ci_vec)
   } else {
     point_estimate <- check_obs_stat(point_estimate)
     multiplier <- stats::qnorm(1 - (1 - level) / 2)
+    
     ci <- tibble::tibble(
       lower = point_estimate - multiplier * stats::sd(x[["stat"]]),
-      upper = point_estimate + multiplier * stats::sd(x[["stat"]]))
+      upper = point_estimate + multiplier * stats::sd(x[["stat"]])
+    )
   }
 
-  return(ci)
+  ci
 }
 
 #' @rdname get_confidence_interval
 #' @export
 get_ci <- function(x, level = 0.95, type = "percentile",
-  point_estimate = NULL) {
+                   point_estimate = NULL) {
   get_confidence_interval(
     x, level = level, type = type, point_estimate = point_estimate
   )
 }
 
 check_ci_args <- function(x, level, type, point_estimate){
-
-  if(!is.null(point_estimate)){
-    if(!is.data.frame(point_estimate))
+  if (!is.null(point_estimate)) {
+    if (!is.data.frame(point_estimate)) {
       check_type(point_estimate, is.numeric)
-    else
+    } else {
       check_type(point_estimate, is.data.frame)
+    }
   }
   check_type(x, is.data.frame)
   check_type(level, is.numeric)
-  if(level <= 0 || level >= 1){
+  
+  if ((level <= 0) || (level >= 1)) {
     stop_glue("The value of `level` must be between 0 and 1 non-inclusive.")
   }
 
-  if(!(type %in% c("percentile", "se"))){
+  if (!(type %in% c("percentile", "se"))) {
     stop_glue('The options for `type` are "percentile" or "se".')
   }
 
-  if(type == "se" && is.null(point_estimate))
-    stop_glue('A numeric value needs to be given for `point_estimate` ',
-      'for `type = "se"')
+  if ((type == "se") && is.null(point_estimate)) {
+    stop_glue(
+      'A numeric value needs to be given for `point_estimate` ',
+      'for `type = "se"'
+    )
+  }
 
-  if(type == "se" && is.vector(point_estimate))
-    check_type(point_estimate, is.numeric)
+  if ((type == "se") && is.vector(point_estimate)) {
+    check_type(point_estimate, is.numeric) 
+  }
 }
 

--- a/R/get_confidence_interval.R
+++ b/R/get_confidence_interval.R
@@ -14,9 +14,10 @@
 #'   Default value is 0.95.
 #' @param type A string giving which method should be used for creating the
 #'   confidence interval. The default is `"percentile"` with `"se"`
-#'   corresponding to (multiplier * standard error) as the other option.
+#'   corresponding to (multiplier * standard error) and `"bias-corrected"` for
+#'   bias-corrected interval as other options.
 #' @param point_estimate A numeric value or a 1x1 data frame set to `NULL` by
-#'   default. Needed to be provided if `type = "se"`.
+#'   default. Needed to be provided if `type` is `"se"` or `"bias-corrected"`.
 #'
 #' @return A 1 x 2 tibble with values corresponding to lower and upper values in
 #'   the confidence interval.

--- a/man/get_confidence_interval.Rd
+++ b/man/get_confidence_interval.Rd
@@ -31,8 +31,8 @@ bias-corrected interval as other options.}
 default. Needed to be provided if \code{type} is \code{"se"} or \code{"bias-corrected"}.}
 }
 \value{
-A 1 x 2 tibble with values corresponding to lower and upper values in
-the confidence interval.
+A 1 x 2 tibble with 'lower_ci' and 'upper_ci' columns. Values
+correspond to lower and upper bounds of the confidence interval.
 }
 \description{
 Compute a confidence interval around a summary statistic. Only

--- a/man/get_confidence_interval.Rd
+++ b/man/get_confidence_interval.Rd
@@ -24,10 +24,11 @@ Default value is 0.95.}
 
 \item{type}{A string giving which method should be used for creating the
 confidence interval. The default is \code{"percentile"} with \code{"se"}
-corresponding to (multiplier * standard error) as the other option.}
+corresponding to (multiplier * standard error) and \code{"bias-corrected"} for
+bias-corrected interval as other options.}
 
 \item{point_estimate}{A numeric value or a 1x1 data frame set to \code{NULL} by
-default. Needed to be provided if \code{type = "se"}.}
+default. Needed to be provided if \code{type} is \code{"se"} or \code{"bias-corrected"}.}
 }
 \value{
 A 1 x 2 tibble with values corresponding to lower and upper values in

--- a/man/get_confidence_interval.Rd
+++ b/man/get_confidence_interval.Rd
@@ -63,11 +63,13 @@ gss \%>\%
   generate(reps = 1000, type = "bootstrap") \%>\%
   # finding the null distribution
   calculate(stat = "mean") \%>\%
-  get_confidence_interval(point_estimate = point_estimate,
-                          # at the 95\% confidence level
-                          level = .95,
-                          # using the standard error method
-                          type = "se")
+  get_confidence_interval(
+    point_estimate = point_estimate,
+    # at the 95\% confidence level
+    level = 0.95,
+    # using the standard error method
+    type = "se"
+  )
   
 # More in-depth explanation of how to use the infer package
 \dontrun{

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -1,20 +1,54 @@
 context("conf_int")
 
-test_that("basics work", {
-  expect_silent(test_df %>% get_confidence_interval())
-  expect_error(test_df %>% get_confidence_interval(type = "other"))
-  expect_error(test_df %>% get_confidence_interval(level = 1.2))
-  expect_error(test_df %>% get_confidence_interval(point_estimate = "help"))
+test_that("get_confidence_interval works", {
+  perc_basic_out <- tibble::tibble(
+    `2.5%`  = quantile(test_df[["stat"]], 0.025),
+    `97.5%` = quantile(test_df[["stat"]], 0.975)
+  )
+  expect_equal(test_df %>% get_confidence_interval(), perc_basic_out)
+  
+  # Type "percentile"
+  expect_equal(
+    test_df %>% get_confidence_interval(type = "percentile"), perc_basic_out
+  )
+  expect_equal(
+    test_df %>% get_confidence_interval(level = 0.5, type = "percentile"),
+    tibble::tibble(
+      `25%` = quantile(test_df[["stat"]], 0.25),
+      `75%` = quantile(test_df[["stat"]], 0.75)
+    )
+  )
+  
+  # Type "se"
+  point <- mean(test_df[["stat"]])
+  expect_equal(
+    test_df %>% get_confidence_interval(type = "se", point_estimate = point),
+    tibble::tibble(lower = -1.965, upper = 2.008),
+    tolerance = 1e-3
+  )
+  expect_equal(
+    test_df %>%
+      get_confidence_interval(level = 0.5, type = "se", point_estimate = point),
+    tibble::tibble(lower = -0.662, upper = 0.705),
+    tolerance = 1e-3
+  )
+})
 
-  expect_silent(gss_calc %>% 
-                  get_confidence_interval(type = "se", 
-                                          point_estimate = 4))
-  expect_silent(gss_calc %>% 
-                  get_confidence_interval(type = "se", 
-                                          point_estimate = obs_diff))
-  expect_error(gss_calc %>% 
-                 get_confidence_interval(type = "se", 
-                                         point_estimate = "error"))
-  expect_error(gss_calc %>% 
-                 get_confidence_interval(type = "se"))
+test_that("get_confidence_interval checks input", {
+  expect_error(test_df %>% get_confidence_interval(type = "other"), "`type`")
+  expect_error(test_df %>% get_confidence_interval(level = 1.2), "`level`")
+  
+  expect_error(
+    test_df %>% get_confidence_interval(point_estimate = "a"),
+    "`point_estimate`"
+  )
+  expect_error(
+    gss_calc %>% get_confidence_interval(type = "se", point_estimate = "a"),
+    "`point_estimate`"
+  )
+  
+  expect_error(
+    gss_calc %>% get_confidence_interval(type = "se"),
+    '`point_estimate`.*type = "se"'
+  )
 })

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -2,8 +2,8 @@ context("conf_int")
 
 test_that("get_confidence_interval works", {
   perc_basic_out <- tibble::tibble(
-    `2.5%`  = quantile(test_df[["stat"]], 0.025),
-    `97.5%` = quantile(test_df[["stat"]], 0.975)
+    `2.5%`  = unname(quantile(test_df[["stat"]], 0.025)),
+    `97.5%` = unname(quantile(test_df[["stat"]], 0.975))
   )
   expect_equal(test_df %>% get_confidence_interval(), perc_basic_out)
   
@@ -14,22 +14,32 @@ test_that("get_confidence_interval works", {
   expect_equal(
     test_df %>% get_confidence_interval(level = 0.5, type = "percentile"),
     tibble::tibble(
-      `25%` = quantile(test_df[["stat"]], 0.25),
-      `75%` = quantile(test_df[["stat"]], 0.75)
+      `25%` = unname(quantile(test_df[["stat"]], 0.25)),
+      `75%` = unname(quantile(test_df[["stat"]], 0.75))
     )
   )
   
   # Type "se"
   point <- mean(test_df[["stat"]])
+  se_basic_out <- tibble::tibble(lower = -1.965, upper = 2.008)
   expect_equal(
     test_df %>% get_confidence_interval(type = "se", point_estimate = point),
-    tibble::tibble(lower = -1.965, upper = 2.008),
+    se_basic_out,
     tolerance = 1e-3
   )
   expect_equal(
     test_df %>%
       get_confidence_interval(level = 0.5, type = "se", point_estimate = point),
     tibble::tibble(lower = -0.662, upper = 0.705),
+    tolerance = 1e-3
+  )
+  ## Check that data frame input is processed correctly
+  expect_equal(
+    test_df %>%
+      get_confidence_interval(
+        type = "se", point_estimate = data.frame(p = point)
+      ),
+    se_basic_out,
     tolerance = 1e-3
   )
 })
@@ -43,12 +53,19 @@ test_that("get_confidence_interval checks input", {
     "`point_estimate`"
   )
   expect_error(
-    gss_calc %>% get_confidence_interval(type = "se", point_estimate = "a"),
+    test_df %>% get_confidence_interval(type = "se", point_estimate = "a"),
     "`point_estimate`"
+  )
+  expect_error(
+    test_df %>%
+      get_confidence_interval(
+        type = "se", point_estimate = data.frame(p = "a")
+      ),
+    "`point_estimate\\[\\[1\\]\\]\\[\\[1\\]\\]`"
   )
   
   expect_error(
-    gss_calc %>% get_confidence_interval(type = "se"),
+    test_df %>% get_confidence_interval(type = "se"),
     '`point_estimate`.*type = "se"'
   )
 })

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -3,8 +3,8 @@ context("get_confidence_interval")
 point <- mean(test_df[["stat"]])
 
 perc_def_out <- tibble::tibble(
-  `2.5%`  = unname(quantile(test_df[["stat"]], 0.025)),
-  `97.5%` = unname(quantile(test_df[["stat"]], 0.975))
+  lower_ci = unname(quantile(test_df[["stat"]], 0.025)),
+  upper_ci = unname(quantile(test_df[["stat"]], 0.975))
 )
 
 test_that("get_confidence_interval works with defaults", {
@@ -25,8 +25,8 @@ test_that("get_confidence_interval works with `type = 'percentile'`", {
   expect_equal(
     test_df %>% get_confidence_interval(level = 0.5, type = "percentile"),
     tibble::tibble(
-      `25%` = unname(quantile(test_df[["stat"]], 0.25)),
-      `75%` = unname(quantile(test_df[["stat"]], 0.75))
+      lower_ci = unname(quantile(test_df[["stat"]], 0.25)),
+      upper_ci = unname(quantile(test_df[["stat"]], 0.75))
     )
   )
 })
@@ -35,7 +35,7 @@ test_that("get_confidence_interval works with `type = 'se'`", {
   expect_message(
     expect_equal(
       test_df %>% get_confidence_interval(type = "se", point_estimate = point),
-      tibble::tibble(lower = -1.965, upper = 2.008),
+      tibble::tibble(lower_ci = -1.965, upper_ci = 2.008),
       tolerance = 1e-3
     ),
     "Using `level = 0.95`"
@@ -44,7 +44,7 @@ test_that("get_confidence_interval works with `type = 'se'`", {
   expect_equal(
     test_df %>%
       get_confidence_interval(level = 0.5, type = "se", point_estimate = point),
-    tibble::tibble(lower = -0.662, upper = 0.705),
+    tibble::tibble(lower_ci = -0.662, upper_ci = 0.705),
     tolerance = 1e-3
   )
 })
@@ -56,7 +56,7 @@ test_that("get_confidence_interval works with `type = 'bias-corrected'`", {
         get_confidence_interval(
           type = "bias-corrected", point_estimate = point
         ),
-      tibble::tibble(lower = -1.692, upper = 2.276),
+      tibble::tibble(lower_ci = -1.692, upper_ci = 2.276),
       tolerance = 1e-3
     ),
     "Using `level = 0.95`"
@@ -67,7 +67,7 @@ test_that("get_confidence_interval works with `type = 'bias-corrected'`", {
       get_confidence_interval(
         level = 0.5, type = "bias-corrected", point_estimate = point
       ),
-    tibble::tibble(lower = -0.594, upper = 0.815),
+    tibble::tibble(lower_ci = -0.594, upper_ci = 0.815),
     tolerance = 1e-3
   )
 })

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -1,10 +1,13 @@
 context("conf_int")
 
 test_that("get_confidence_interval works", {
+  point <- mean(test_df[["stat"]])
+  
   perc_basic_out <- tibble::tibble(
     `2.5%`  = unname(quantile(test_df[["stat"]], 0.025)),
     `97.5%` = unname(quantile(test_df[["stat"]], 0.975))
   )
+  
   expect_equal(test_df %>% get_confidence_interval(), perc_basic_out)
   
   # Type "percentile"
@@ -20,8 +23,8 @@ test_that("get_confidence_interval works", {
   )
   
   # Type "se"
-  point <- mean(test_df[["stat"]])
   se_basic_out <- tibble::tibble(lower = -1.965, upper = 2.008)
+  
   expect_equal(
     test_df %>% get_confidence_interval(type = "se", point_estimate = point),
     se_basic_out,
@@ -40,6 +43,33 @@ test_that("get_confidence_interval works", {
         type = "se", point_estimate = data.frame(p = point)
       ),
     se_basic_out,
+    tolerance = 1e-3
+  )
+  
+  # Type "bias-corrected"
+  bias_basic_out <- tibble::tibble(lower = -1.692, upper = 2.276)
+  
+  expect_equal(
+    test_df %>%
+      get_confidence_interval(type = "bias-corrected", point_estimate = point),
+    bias_basic_out,
+    tolerance = 1e-3
+  )
+  expect_equal(
+    test_df %>%
+      get_confidence_interval(
+        level = 0.5, type = "bias-corrected", point_estimate = point
+      ),
+    tibble::tibble(lower = -0.594, upper = 0.815),
+    tolerance = 1e-3
+  )
+  ## Check that data frame input is processed correctly
+  expect_equal(
+    test_df %>%
+      get_confidence_interval(
+        type = "bias-corrected", point_estimate = data.frame(p = point)
+      ),
+    bias_basic_out,
     tolerance = 1e-3
   )
 })
@@ -65,7 +95,10 @@ test_that("get_confidence_interval checks input", {
   )
   
   expect_error(
-    test_df %>% get_confidence_interval(type = "se"),
-    '`point_estimate`.*type = "se"'
+    test_df %>% get_confidence_interval(type = "se"), '`point_estimate`.*"se"'
+  )
+  expect_error(
+    test_df %>% get_confidence_interval(type = "bias-corrected"),
+    '`point_estimate`.*"bias-corrected"'
   )
 })

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -8,11 +8,18 @@ test_that("get_confidence_interval works", {
     `97.5%` = unname(quantile(test_df[["stat"]], 0.975))
   )
   
-  expect_equal(test_df %>% get_confidence_interval(), perc_basic_out)
+  # Default usage
+  expect_message(
+    expect_equal(test_df %>% get_confidence_interval(), perc_basic_out),
+    "Using `level = 0.95`"
+  )
   
   # Type "percentile"
-  expect_equal(
-    test_df %>% get_confidence_interval(type = "percentile"), perc_basic_out
+  expect_message(
+    expect_equal(
+      test_df %>% get_confidence_interval(type = "percentile"), perc_basic_out
+    ),
+    "Using `level = 0.95`"
   )
   expect_equal(
     test_df %>% get_confidence_interval(level = 0.5, type = "percentile"),
@@ -25,10 +32,13 @@ test_that("get_confidence_interval works", {
   # Type "se"
   se_basic_out <- tibble::tibble(lower = -1.965, upper = 2.008)
   
-  expect_equal(
-    test_df %>% get_confidence_interval(type = "se", point_estimate = point),
-    se_basic_out,
-    tolerance = 1e-3
+  expect_message(
+    expect_equal(
+      test_df %>% get_confidence_interval(type = "se", point_estimate = point),
+      se_basic_out,
+      tolerance = 1e-3
+    ),
+    "Using `level = 0.95`"
   )
   expect_equal(
     test_df %>%
@@ -37,23 +47,31 @@ test_that("get_confidence_interval works", {
     tolerance = 1e-3
   )
   ## Check that data frame input is processed correctly
-  expect_equal(
-    test_df %>%
-      get_confidence_interval(
-        type = "se", point_estimate = data.frame(p = point)
-      ),
-    se_basic_out,
-    tolerance = 1e-3
+  expect_message(
+    expect_equal(
+      test_df %>%
+        get_confidence_interval(
+          type = "se", point_estimate = data.frame(p = point)
+        ),
+      se_basic_out,
+      tolerance = 1e-3
+    ),
+    "Using `level = 0.95`"
   )
   
   # Type "bias-corrected"
   bias_basic_out <- tibble::tibble(lower = -1.692, upper = 2.276)
   
-  expect_equal(
-    test_df %>%
-      get_confidence_interval(type = "bias-corrected", point_estimate = point),
-    bias_basic_out,
-    tolerance = 1e-3
+  expect_message(
+    expect_equal(
+      test_df %>%
+        get_confidence_interval(
+          type = "bias-corrected", point_estimate = point
+        ),
+      bias_basic_out,
+      tolerance = 1e-3
+    ),
+    "Using `level = 0.95`"
   )
   expect_equal(
     test_df %>%
@@ -64,13 +82,16 @@ test_that("get_confidence_interval works", {
     tolerance = 1e-3
   )
   ## Check that data frame input is processed correctly
-  expect_equal(
-    test_df %>%
-      get_confidence_interval(
-        type = "bias-corrected", point_estimate = data.frame(p = point)
-      ),
-    bias_basic_out,
-    tolerance = 1e-3
+  expect_message(
+    expect_equal(
+      test_df %>%
+        get_confidence_interval(
+          type = "bias-corrected", point_estimate = data.frame(p = point)
+        ),
+      bias_basic_out,
+      tolerance = 1e-3
+    ),
+    "Using `level = 0.95`"
   )
 })
 


### PR DESCRIPTION
This PR updates `get_confidence_interval()` in the following ways:

- There is new `type = "bias-corrected"` following #237's initial implementation.
- Outputs for different `type` values now have consistent column names (#317).
- Message is given if `level` isn't explicitly supplied (following [this discussion](https://github.com/tidymodels/infer/issues/317#issuecomment-647158567)).
- Tests are now more thorough.
- Code is slightly refactored.