### PR TITLE
launch infer.tidymodels.org

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches: master
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_dev("pkgdown")
+          remotes::install_github("tidyverse/tidytemplate")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,8 +1,20 @@
+url: https://infer.tidymodels.org
+
 template:
+  package: tidytemplate
   params:
-    docsearch:
-      api_key: 33338960d0dcb55ff924a40c2f749a0d
-      index_name: infer
+    theme: tidymodels
+    part_of: <a href="https://github.com/tidymodels">tidymodels</a>
+    footer: infer is a part of the <strong>tidymodels</strong> ecosystem, a collection of modeling packages designed with common APIs and a shared philosophy.
+
+# https://github.com/tidyverse/tidytemplate for css
+
+development:
+  mode: auto
+
+figures:
+  fig.width: 8
+  fig.height: 5.75
 
 home:
   title: infer - Tidy Statistical Inference

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+infer.tidymodels.org


### PR DESCRIPTION
infer's CNAME entry is now set up with RStudio! This commit, if merged to `master`, should set up build commands to send a tidymodels-style pkgdown site to infer.tidymodels.org. This will likely break updates to the existing site, but we can temporarily restore the old website while we get the new one up and running, and then set up automatic redirects from the old site to this one easily through the Netlify UI. (This setup is what we used to get [stacks.tidymodels.org](https://stacks.tidymodels.org) up and running.. there might be some differences in the setup for new sites vs packages with previously existing ones.)

Once this is merged…
* restore [infer.netlify.com](https://infer.netlify.com) to host the build from the previous commit through the Netlify UI
* wait… the CNAME will take maybe 10-20 minutes to register, IIRC
* once infer.tidymodels.org is up and running, set up redirects from the old site to the new one through the Netlify UI

If we want to still host a dev website, we should be able to set up a branch deploy through the Netlify UI to develop.infer.tidymodels.org

I’ll be around this afternoon to troubleshoot!

cc @andrewpbray