### PR TITLE
Error msg tweak

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -124,7 +124,7 @@ check_order <- function(x, explanatory_variable, order, in_calculate = TRUE) {
   unique_ex <- sort(unique(explanatory_variable))
   if (length(unique_ex) != 2) {
     stop_glue(
-      "Statistic is based on a difference or ratio; the explanatory variable", 
+      "Statistic is based on a difference or ratio; the explanatory variable ", 
       "should have two levels."
     )
   }


### PR DESCRIPTION
To change `Error: Statistic is based on a difference or ratio; the explanatory variableshould have two levels.` to `Error: Statistic is based on a difference or ratio; the explanatory variable should have two levels.`