### PR TITLE
add success argument to prop_test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Added `rep_slice_sample()`, a light wrapper around `rep_sample_n()`, that
 more closely resembles `dplyr::slice_sample()` (the function that supersedes)
 `dplyr::sample_n()` (#325)
+- Added a `success` argument to `prop_test()` (#343)
 
 # infer 0.5.3
 

--- a/R/infer.R
+++ b/R/infer.R
@@ -22,7 +22,7 @@ if (getRversion() >= "2.15.1") {
       "parameter", "p.value", "xmin", "x_min", "xmax", "x_max", "density",
       "denom", "diff_prop", "group_num", "n1", "n2", "num_suc", "p_hat",
       "total_suc", "explan", "probs", "conf.low", "conf.high", "prop_1",
-      "prop_2", "data", "relevel"
+      "prop_2", "data"
     )
   )
 }

--- a/R/infer.R
+++ b/R/infer.R
@@ -22,7 +22,7 @@ if (getRversion() >= "2.15.1") {
       "parameter", "p.value", "xmin", "x_min", "xmax", "x_max", "density",
       "denom", "diff_prop", "group_num", "n1", "n2", "num_suc", "p_hat",
       "total_suc", "explan", "probs", "conf.low", "conf.high", "prop_1",
-      "prop_2", "data"
+      "prop_2", "data", "relevel"
     )
   )
 }

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -492,8 +492,7 @@ prop_test <- function(x, formula,
                                alternative = alternative,
                                conf.level = conf_level,
                                p = p,
-                               ...) %>%
-      broom::glance()
+                               ...)
   } else { # one sample
     response_tbl <- response_variable(x) %>%
       factor() %>%
@@ -511,13 +510,14 @@ prop_test <- function(x, formula,
                                alternative = alternative,
                                conf.level = conf_level,
                                p = p,
-                               ...) %>%
-      broom::glance()
+                               ...)
+      
   }
 
-  if (prelim$parameter <= 2) {
+  if (length(prelim$estimate) <= 2) {
     if (conf_int & is.null(p)) {
        results <- prelim %>%
+         broom::glance() %>%
          dplyr::select(statistic,
                        chisq_df = parameter,
                        p_value = p.value,
@@ -526,6 +526,7 @@ prop_test <- function(x, formula,
                        upper_ci = conf.high)
     } else {
        results <- prelim %>%
+         broom::glance() %>%
          dplyr::select(statistic,
                        chisq_df = parameter,
                        p_value = p.value,
@@ -533,6 +534,7 @@ prop_test <- function(x, formula,
     }
   } else {
     results <- prelim %>%
+      broom::glance() %>%
       dplyr::select(statistic,
                     chisq_df = parameter,
                     p_value = p.value)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -461,12 +461,12 @@ prop_test <- function(x, formula,
   lvls <- levels(factor(response_variable(x)))
 
   if (!is.null(success)) {
-    if (!is.character(success)) {
-      stop_glue("`success` must be a string.")
-    }
+    check_type(success, rlang::is_string)
+
     if (!(success %in% lvls)) {
       stop_glue('{success} is not a valid level of {attr(x, "response")}.')
     }
+
     lvls <- c(success, lvls[lvls != success])
   } else {
     success <- lvls[1]
@@ -497,7 +497,7 @@ prop_test <- function(x, formula,
   } else { # one sample
     response_tbl <- response_variable(x) %>%
       factor() %>%
-      relevel(success) %>%
+      stats::relevel(success) %>%
       table()
 
     if (is.null(p)) {
@@ -515,21 +515,22 @@ prop_test <- function(x, formula,
       broom::glance()
   }
 
-  if (conf_int & is.null(p) & (prelim$parameter <= 2)) {
-     results <- prelim %>%
-       dplyr::select(statistic,
-                     chisq_df = parameter,
-                     p_value = p.value,
-                     alternative,
-                     lower_ci = conf.low,
-                     upper_ci = conf.high)
-
-  } else if (prelim$parameter <= 2) {
-     results <- prelim %>%
-       dplyr::select(statistic,
-                     chisq_df = parameter,
-                     p_value = p.value,
-                     alternative)
+  if (prelim$parameter <= 2) {
+    if (conf_int & is.null(p)) {
+       results <- prelim %>%
+         dplyr::select(statistic,
+                       chisq_df = parameter,
+                       p_value = p.value,
+                       alternative,
+                       lower_ci = conf.low,
+                       upper_ci = conf.high)
+    } else {
+       results <- prelim %>%
+         dplyr::select(statistic,
+                       chisq_df = parameter,
+                       p_value = p.value,
+                       alternative)
+    }
   } else {
     results <- prelim %>%
       dplyr::select(statistic,

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -458,17 +458,17 @@ prop_test <- function(x, formula,
   }
   
   # process "success" arg
+  lvls <- levels(factor(response_variable(x)))
+  
   if (!is.null(success)) {
     if (!is.character(success)) {
       stop_glue("`success` must be a string.")
     }
-    if (!(success %in% levels(response_variable(x)))) {
+    if (!(success %in% lvls)) {
       stop_glue('{success} is not a valid level of {attr(x, "response")}.')
     }
-    lvls <- levels(factor(response_variable(x)))
     lvls <- c(success, lvls[lvls != success])
   } else {
-    lvls <- levels(response_variable(x))
     success <- lvls[1]
   }
   

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -30,7 +30,7 @@
 #'
 #' @examples
 #' library(tidyr)
-#' 
+#'
 #' # t test for number of hours worked per week
 #' # by college degree status
 #' gss %>%
@@ -40,45 +40,45 @@
 #'       alternative = "two-sided")
 #'
 #' # see vignette("infer") for more explanation of the
-#' # intuition behind the infer package, and vignette("t_test") 
+#' # intuition behind the infer package, and vignette("t_test")
 #' # for more examples of t-tests using infer
 #'
 #' @importFrom rlang f_lhs
 #' @importFrom rlang f_rhs
 #' @importFrom stats as.formula
 #' @export
-t_test <- function(x, formula, 
-                   response = NULL, 
+t_test <- function(x, formula,
+                   response = NULL,
                    explanatory = NULL,
                    order = NULL,
-                   alternative = "two-sided", 
+                   alternative = "two-sided",
                    mu = 0,
                    conf_int = TRUE,
                    conf_level = 0.95,
                    ...) {
   check_conf_level(conf_level)
-  
+
   # convert all character and logical variables to be factor variables
   x <- tibble::as_tibble(x) %>%
     mutate_if(is.character, as.factor) %>%
     mutate_if(is.logical, as.factor)
-  
+
   # parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
-  x <- parse_variables(x = x, formula = formula, 
+  x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
-  
+
   # match with old "dot" syntax in t.test
   if (alternative %in% c("two-sided", "two_sided", "two sided")) {
     alternative <- "two.sided"
   }
-  
+
   # two sample
   if (has_explanatory(x)) {
     # if (!is.null(order)) {
-    #   x[[as.character(attr(x, "explanatory"))]] <- factor(explanatory_variable(x), 
-    #                                                       levels = c(order[1], 
+    #   x[[as.character(attr(x, "explanatory"))]] <- factor(explanatory_variable(x),
+    #                                                       levels = c(order[1],
     #                                                                  order[2]),
     #                                                       ordered = TRUE)
     # }
@@ -100,7 +100,7 @@ t_test <- function(x, formula,
                             conf.level = conf_level) %>%
       broom::glance()
   }
-  
+
   if (conf_int) {
     results <- prelim %>%
       dplyr::select(
@@ -113,14 +113,14 @@ t_test <- function(x, formula,
         statistic, t_df = parameter, p_value = p.value, alternative
       )
   }
-  
+
   results
 }
 
 #' Tidy t-test statistic
 #'
 #' @description
-#' 
+#'
 #' A shortcut wrapper function to get the observed test statistic for a t test.
 #'
 #' @param x A data frame that can be coerced into a [tibble][tibble::tibble].
@@ -144,7 +144,7 @@ t_test <- function(x, formula,
 #'
 #' @examples
 #' library(tidyr)
-#' 
+#'
 #' # t test statistic for true mean number of hours worked
 #' # per week of 40
 #' gss %>%
@@ -159,38 +159,38 @@ t_test <- function(x, formula,
 #'       alternative = "two-sided")
 #'
 #' @export
-t_stat <- function(x, formula, 
-                   response = NULL, 
+t_stat <- function(x, formula,
+                   response = NULL,
                    explanatory = NULL,
                    order = NULL,
-                   alternative = "two-sided", 
+                   alternative = "two-sided",
                    mu = 0,
                    conf_int = FALSE,
                    conf_level = 0.95,
                    ...) {
   check_conf_level(conf_level)
-  
+
   # convert all character and logical variables to be factor variables
   x <- tibble::as_tibble(x) %>%
     mutate_if(is.character, as.factor) %>%
     mutate_if(is.logical, as.factor)
-  
+
   # parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
-  x <- parse_variables(x = x, formula = formula, 
+  x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
-  
+
   # match with old "dot" syntax in t.test
   if (alternative %in% c("two-sided", "two_sided", "two sided")) {
     alternative <- "two.sided"
   }
-  
+
   # two sample
   if (has_explanatory(x)) {
     # if (!is.null(order)) {
-    #   x[[as.character(attr(x, "explanatory"))]] <- factor(explanatory_variable(x), 
-    #                                                       levels = c(order[1], 
+    #   x[[as.character(attr(x, "explanatory"))]] <- factor(explanatory_variable(x),
+    #                                                       levels = c(order[1],
     #                                                                  order[2]),
     #                                                       ordered = TRUE)
     # }
@@ -212,13 +212,13 @@ t_stat <- function(x, formula,
                             conf.level = conf_level) %>%
       broom::glance()
   }
-  
-  # removed unnecessary if(conf_int) clause; only the statistic itself 
+
+  # removed unnecessary if(conf_int) clause; only the statistic itself
   # was returned regardless
   results <- prelim %>%
     dplyr::select(statistic) %>%
     pull()
-  
+
   results
 }
 
@@ -239,13 +239,13 @@ t_stat <- function(x, formula,
 #' @param ... Additional arguments for [chisq.test()][stats::chisq.test()].
 #'
 #' @examples
-#' # chi-squared test of independence for college completion 
+#' # chi-squared test of independence for college completion
 #' # status depending on one's self-identified income class
 #' chisq_test(gss, college ~ finrela)
-#' 
-#' # chi-squared goodness of fit test on whether self-identified 
+#'
+#' # chi-squared goodness of fit test on whether self-identified
 #' # income class follows a uniform distribution
-#' chisq_test(gss, 
+#' chisq_test(gss,
 #'            response = finrela,
 #'            p = c("far below average" = 1/6,
 #'                  "below average" = 1/6,
@@ -255,35 +255,35 @@ t_stat <- function(x, formula,
 #'                  "DK" = 1/6))
 #'
 #' @export
-chisq_test <- function(x, formula, response = NULL, 
+chisq_test <- function(x, formula, response = NULL,
                        explanatory = NULL, ...) {
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
-  x <- parse_variables(x = x, formula = formula, 
+  x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
-  
+
   if (!(class(response_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The response variable of `{attr(x, "response")}` is not appropriate\n',
       "since the response variable is expected to be categorical."
     )
   }
-  if (has_explanatory(x) && 
+  if (has_explanatory(x) &&
       !(class(explanatory_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The explanatory variable of `{attr(x, "explanatory")}` is not appropriate\n',
       "since the explanatory variable is expected to be categorical."
     )
   }
-  
+
   x <- x %>%
     select(one_of(c(
       as.character((attr(x, "response"))), as.character(attr(x, "explanatory"))
     ))) %>%
     mutate_if(is.character, as.factor) %>%
     mutate_if(is.logical, as.factor)
-  
+
   stats::chisq.test(table(x), ...) %>%
     broom::glance() %>%
     dplyr::select(statistic, chisq_df = parameter, p_value = p.value)
@@ -307,15 +307,15 @@ chisq_test <- function(x, formula, response = NULL,
 #' @param ... Additional arguments for [chisq.test()][stats::chisq.test()].
 #'
 #' @examples
-#' # chi-squared test statistic for test of independence 
-#' # of college completion status depending and one's 
+#' # chi-squared test statistic for test of independence
+#' # of college completion status depending and one's
 #' # self-identified income class
 #' chisq_stat(gss, college ~ finrela)
-#' 
-#' # chi-squared test statistic for a goodness of fit 
-#' # test on whether self-identified income class 
+#'
+#' # chi-squared test statistic for a goodness of fit
+#' # test on whether self-identified income class
 #' # follows a uniform distribution
-#' chisq_stat(gss, 
+#' chisq_stat(gss,
 #'            response = finrela,
 #'            p = c("far below average" = 1/6,
 #'                  "below average" = 1/6,
@@ -325,35 +325,35 @@ chisq_test <- function(x, formula, response = NULL,
 #'                  "DK" = 1/6))
 #'
 #' @export
-chisq_stat <- function(x, formula, response = NULL, 
+chisq_stat <- function(x, formula, response = NULL,
                        explanatory = NULL, ...) {
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
-  x <- parse_variables(x = x, formula = formula, 
+  x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
-  
+
   if (!(class(response_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The response variable of `{attr(x, "response")}` is not appropriate\n',
       "since the response variable is expected to be categorical."
     )
   }
-  if (has_explanatory(x) && 
+  if (has_explanatory(x) &&
       !(class(explanatory_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The explanatory variable of `{attr(x, "explanatory")}` is not appropriate\n',
       "since the response variable is expected to be categorical."
     )
   }
-  
+
   x <- x %>%
     select(one_of(c(
       as.character((attr(x, "response"))), as.character(attr(x, "explanatory"))
     ))) %>%
     mutate_if(is.character, as.factor) %>%
     mutate_if(is.logical, as.factor)
-  
+
   suppressWarnings(stats::chisq.test(table(x), ...)) %>%
     broom::glance() %>%
     dplyr::select(statistic) %>%
@@ -386,49 +386,49 @@ check_conf_level <- function(conf_level) {
 #'   explanatory variable. Optional. This is an alternative to the formula
 #'   interface.
 #' @param order A string vector specifying the order in which the proportions
-#'   should be subtracted, where  `order = c("first", "second")` means 
-#'   `"first" - "second"`. Ignored for one-sample tests, and optional for two 
+#'   should be subtracted, where  `order = c("first", "second")` means
+#'   `"first" - "second"`. Ignored for one-sample tests, and optional for two
 #'   sample tests.
 #' @param alternative Character string giving the direction of the alternative
-#'   hypothesis. Options are `"two-sided"` (default), `"greater"`, or `"less"`. 
-#'   Only used when testing the null that a single proportion equals a given 
+#'   hypothesis. Options are `"two-sided"` (default), `"greater"`, or `"less"`.
+#'   Only used when testing the null that a single proportion equals a given
 #'   value, or that two proportions are equal; ignored otherwise.
 #' @param p A numeric vector giving the hypothesized null proportion of
 #' success for each group.
 #' @param conf_int A logical value for whether to report the confidence
 #'   interval or not. `TRUE` by default, ignored if `p` is specified for a
-#'   two-sample test. Only used when testing the null that a single 
-#'   proportion equals a given value, or that two proportions are equal; 
+#'   two-sample test. Only used when testing the null that a single
+#'   proportion equals a given value, or that two proportions are equal;
 #'   ignored otherwise.
-#' @param conf_level A numeric value between 0 and 1. Default value is 0.95. 
-#'   Only used when testing the null that a single proportion equals a given 
+#' @param conf_level A numeric value between 0 and 1. Default value is 0.95.
+#'   Only used when testing the null that a single proportion equals a given
 #'   value, or that two proportions are equal; ignored otherwise.
 #' @param success The level of `response` that will be considered a success, as
-#'   a string. Only used when testing the null that a single 
-#'   proportion equals a given value, or that two proportions are equal; 
+#'   a string. Only used when testing the null that a single
+#'   proportion equals a given value, or that two proportions are equal;
 #'   ignored otherwise.
 #' @param ... Additional arguments for [prop.test()][stats::prop.test()].
 #'
 #' @examples
-#' # two-sample proportion test for difference in proportions of 
+#' # two-sample proportion test for difference in proportions of
 #' # college completion by respondent sex
-#' prop_test(gss, 
-#'           college ~ sex,  
+#' prop_test(gss,
+#'           college ~ sex,
 #'           order = c("female", "male"))
-#'           
-#' # one-sample proportion test for hypothesized null 
+#'
+#' # one-sample proportion test for hypothesized null
 #' # proportion of college completion of .2
 #' prop_test(gss,
 #'           college ~ NULL,
 #'           p = .2)
 #'
 #' @export
-prop_test <- function(x, formula, 
-                      response = NULL, 
+prop_test <- function(x, formula,
+                      response = NULL,
                       explanatory = NULL,
                       p = NULL,
                       order = NULL,
-                      alternative = "two-sided", 
+                      alternative = "two-sided",
                       conf_int = TRUE,
                       conf_level = 0.95,
                       success = NULL,
@@ -436,16 +436,16 @@ prop_test <- function(x, formula,
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
-  x <- parse_variables(x = x, formula = formula, 
+  x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
-  
+
   if (!(class(response_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The response variable of `{attr(x, "response")}` is not appropriate\n',
       "since the response variable is expected to be categorical."
     )
   }
-  if (has_explanatory(x) && 
+  if (has_explanatory(x) &&
       !(class(explanatory_variable(x)) %in% c("logical", "character", "factor"))) {
     stop_glue(
       'The explanatory variable of `{attr(x, "explanatory")}` is not appropriate\n',
@@ -456,10 +456,10 @@ prop_test <- function(x, formula,
   if (alternative %in% c("two-sided", "two_sided", "two sided")) {
     alternative <- "two.sided"
   }
-  
+
   # process "success" arg
   lvls <- levels(factor(response_variable(x)))
-  
+
   if (!is.null(success)) {
     if (!is.character(success)) {
       stop_glue("`success` must be a string.")
@@ -471,23 +471,23 @@ prop_test <- function(x, formula,
   } else {
     success <- lvls[1]
   }
-  
+
   # two sample
   if (has_explanatory(x)) {
-    
+
     order <- check_order(x, explanatory_variable(x), order, in_calculate = FALSE)
-    
+
     # make a summary table to supply to prop.test
     sum_table <- x %>%
-      select(as.character((attr(x, "response"))), 
+      select(as.character((attr(x, "response"))),
              as.character(attr(x, "explanatory"))) %>%
       mutate_if(is.character, as.factor) %>%
       mutate_if(is.logical, as.factor) %>%
       table()
-    
+
     # reorder according to the order and success arguments
     sum_table <- sum_table[lvls, order]
-    
+
     prelim <- stats::prop.test(x = sum_table,
                                alternative = alternative,
                                conf.level = conf_level,
@@ -499,14 +499,14 @@ prop_test <- function(x, formula,
       factor() %>%
       relevel(success) %>%
       table()
-    
+
     if (is.null(p)) {
       message_glue(
         "No `p` argument was hypothesized, so the test will ",
         "assume a null hypothesis `p = .5`."
       )
     }
-    
+
     prelim <- stats::prop.test(x = response_tbl,
                                alternative = alternative,
                                conf.level = conf_level,
@@ -514,29 +514,29 @@ prop_test <- function(x, formula,
                                ...) %>%
       broom::glance()
   }
-  
+
   if (conf_int & is.null(p) & (prelim$parameter <= 2)) {
      results <- prelim %>%
-       dplyr::select(statistic, 
-                     chisq_df = parameter, 
-                     p_value = p.value, 
+       dplyr::select(statistic,
+                     chisq_df = parameter,
+                     p_value = p.value,
                      alternative,
-                     lower_ci = conf.low, 
+                     lower_ci = conf.low,
                      upper_ci = conf.high)
-    
+
   } else if (prelim$parameter <= 2) {
      results <- prelim %>%
-       dplyr::select(statistic, 
-                     chisq_df = parameter, 
-                     p_value = p.value, 
+       dplyr::select(statistic,
+                     chisq_df = parameter,
+                     p_value = p.value,
                      alternative)
   } else {
     results <- prelim %>%
-      dplyr::select(statistic, 
-                    chisq_df = parameter, 
+      dplyr::select(statistic,
+                    chisq_df = parameter,
                     p_value = p.value)
   }
-  
+
   results
 }
 

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -465,7 +465,7 @@ prop_test <- function(x, formula,
     if (!(success %in% levels(response_variable(x)))) {
       stop_glue('{success} is not a valid level of {attr(x, "response")}.')
     }
-    lvls <- levels(response_variable(x))
+    lvls <- levels(factor(response_variable(x)))
     lvls <- c(success, lvls[lvls != success])
   } else {
     lvls <- levels(response_variable(x))
@@ -496,6 +496,7 @@ prop_test <- function(x, formula,
       broom::glance()
   } else { # one sample
     response_tbl <- response_variable(x) %>%
+      factor() %>%
       relevel(success) %>%
       table()
     

--- a/man/chisq_stat.Rd
+++ b/man/chisq_stat.Rd
@@ -29,15 +29,15 @@ test. Uses \link[stats:chisq.test]{chisq.test()}, which applies a continuity
 correction.
 }
 \examples{
-# chi-squared test statistic for test of independence 
-# of college completion status depending and one's 
+# chi-squared test statistic for test of independence
+# of college completion status depending and one's
 # self-identified income class
 chisq_stat(gss, college ~ finrela)
 
-# chi-squared test statistic for a goodness of fit 
-# test on whether self-identified income class 
+# chi-squared test statistic for a goodness of fit
+# test on whether self-identified income class
 # follows a uniform distribution
-chisq_stat(gss, 
+chisq_stat(gss,
            response = finrela,
            p = c("far below average" = 1/6,
                  "below average" = 1/6,

--- a/man/chisq_test.Rd
+++ b/man/chisq_test.Rd
@@ -25,13 +25,13 @@ A tidier version of \link[stats:chisq.test]{chisq.test()} for goodness of fit
 tests and tests of independence.
 }
 \examples{
-# chi-squared test of independence for college completion 
+# chi-squared test of independence for college completion
 # status depending on one's self-identified income class
 chisq_test(gss, college ~ finrela)
 
-# chi-squared goodness of fit test on whether self-identified 
+# chi-squared goodness of fit test on whether self-identified
 # income class follows a uniform distribution
-chisq_test(gss, 
+chisq_test(gss,
            response = finrela,
            p = c("far below average" = 1/6,
                  "below average" = 1/6,

--- a/man/prop_test.Rd
+++ b/man/prop_test.Rd
@@ -14,6 +14,7 @@ prop_test(
   alternative = "two-sided",
   conf_int = TRUE,
   conf_level = 0.95,
+  success = NULL,
   ...
 )
 }
@@ -41,13 +42,24 @@ should be subtracted, where  \code{order = c("first", "second")} means
 sample tests.}
 
 \item{alternative}{Character string giving the direction of the alternative
-hypothesis. Options are \code{"two-sided"} (default), \code{"greater"}, or \code{"less"}.}
+hypothesis. Options are \code{"two-sided"} (default), \code{"greater"}, or \code{"less"}.
+Only used when testing the null that a single proportion equals a given
+value, or that two proportions are equal; ignored otherwise.}
 
 \item{conf_int}{A logical value for whether to report the confidence
 interval or not. \code{TRUE} by default, ignored if \code{p} is specified for a
-two-sample test.}
+two-sample test. Only used when testing the null that a single
+proportion equals a given value, or that two proportions are equal;
+ignored otherwise.}
 
-\item{conf_level}{A numeric value between 0 and 1. Default value is 0.95.}
+\item{conf_level}{A numeric value between 0 and 1. Default value is 0.95.
+Only used when testing the null that a single proportion equals a given
+value, or that two proportions are equal; ignored otherwise.}
+
+\item{success}{The level of \code{response} that will be considered a success, as
+a string. Only used when testing the null that a single
+proportion equals a given value, or that two proportions are equal;
+ignored otherwise.}
 
 \item{...}{Additional arguments for \link[stats:prop.test]{prop.test()}.}
 }
@@ -56,13 +68,13 @@ A tidier version of \link[stats:prop.test]{prop.test()} for equal or given
 proportions.
 }
 \examples{
-# proportion test for difference in proportions of 
+# two-sample proportion test for difference in proportions of 
 # college completion by respondent sex
 prop_test(gss, 
           college ~ sex,  
           order = c("female", "male"))
           
-# a one-proportion test for hypothesized null 
+# one-sample proportion test for hypothesized null 
 # proportion of college completion of .2
 prop_test(gss,
           college ~ NULL,

--- a/man/prop_test.Rd
+++ b/man/prop_test.Rd
@@ -68,13 +68,13 @@ A tidier version of \link[stats:prop.test]{prop.test()} for equal or given
 proportions.
 }
 \examples{
-# two-sample proportion test for difference in proportions of 
+# two-sample proportion test for difference in proportions of
 # college completion by respondent sex
-prop_test(gss, 
-          college ~ sex,  
+prop_test(gss,
+          college ~ sex,
           order = c("female", "male"))
-          
-# one-sample proportion test for hypothesized null 
+
+# one-sample proportion test for hypothesized null
 # proportion of college completion of .2
 prop_test(gss,
           college ~ NULL,

--- a/man/t_test.Rd
+++ b/man/t_test.Rd
@@ -60,7 +60,7 @@ gss \%>\%
       alternative = "two-sided")
 
 # see vignette("infer") for more explanation of the
-# intuition behind the infer package, and vignette("t_test") 
+# intuition behind the infer package, and vignette("t_test")
 # for more examples of t-tests using infer
 
 }

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -226,7 +226,8 @@ df <- data.frame(resp = c(rep("c", 450),
                           rep("d", 50),
                           rep("c", 400),
                           rep("d", 100)),
-                 exp = rep(c("a", "b"), each = 500))
+                 exp = rep(c("a", "b"), each = 500),
+                 stringsAsFactors = FALSE)
 
 sum_df <- table(df)
 
@@ -323,4 +324,21 @@ test_that("one sample prop_test works", {
   infer3 <- prop_test(df_1, resp ~ NULL, p = .2, success = "c")
   infer4 <- prop_test(df_1, resp ~ NULL, p = .8, success = "d")
   expect_equal(infer3[["chisq_df"]], infer4[["chisq_df"]], tolerance = .001)
+})
+
+test_that("prop_test output dimensionality is correct", {
+  infer_1_sample <- prop_test(df, resp ~ NULL, p = .5)
+  infer_2_sample <- prop_test(df, resp ~ exp, order = c("a", "b"))
+  infer_2_sample_no_int <- prop_test(df, resp ~ exp, order = c("a", "b"), 
+                                     conf_int = FALSE)
+  
+  # introduce a third response level
+  df$resp[c(1:10, 490:510, 990:1000)] <- "e"
+  
+  infer_3_sample <- prop_test(df, resp ~ exp, order = c("a", "b"))
+  
+  expect_length(infer_1_sample, 4)
+  expect_length(infer_2_sample, 6)
+  expect_length(infer_2_sample_no_int, 4)
+  expect_length(infer_3_sample, 3)
 })

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -196,7 +196,7 @@ test_that("conf_int argument works", {
 
   # Check that var.equal produces different results
   # Thanks for fmaleing this @EllaKaye!
-  gss_tbl_small <- gss_tbl %>% slice(1:6, 90:100)
+  gss_tbl_small <- gss_tbl %>% dplyr::slice(1:6, 90:100)
 
   no_var_equal <- gss_tbl_small %>%
     t_stat(hours ~ sex, order = c("female", "male"))

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -7,29 +7,29 @@ test_that("t_test works", {
   expect_error(
     gss_tbl %>% t_test(response = "hours", explanatory = "sex")
   )
-  
-  new_way <- t_test(gss_tbl, 
-                    hours ~ sex, 
+
+  new_way <- t_test(gss_tbl,
+                    hours ~ sex,
                     order = c("male", "female"))
-  new_way_alt <- t_test(gss_tbl, 
+  new_way_alt <- t_test(gss_tbl,
                     response = hours,
                     explanatory = sex,
                     order = c("male", "female"))
   old_way <- t.test(hours ~ sex, data = gss_tbl) %>%
     broom::glance() %>%
-    dplyr::select(statistic, t_df = parameter, p_value = p.value, 
+    dplyr::select(statistic, t_df = parameter, p_value = p.value,
                   alternative, lower_ci = conf.low, upper_ci = conf.high)
-  
+
   expect_equal(new_way, new_way_alt, tolerance = 1e-5)
   expect_equal(new_way, old_way, tolerance = 1e-5)
-  
+
   # check that the order argument changes output
-  new_way2 <- t_test(gss_tbl, 
-                    hours ~ sex, 
-                    order = c("female", "male"))  
+  new_way2 <- t_test(gss_tbl,
+                    hours ~ sex,
+                    order = c("female", "male"))
   expect_equal(new_way[["lower_ci"]], -new_way2[["upper_ci"]])
   expect_equal(new_way[["statistic"]], -new_way2[["statistic"]])
-  
+
   # One Sample
   new_way <- gss_tbl %>%
     t_test(hours ~ NULL, mu = 0)
@@ -37,20 +37,20 @@ test_that("t_test works", {
     t_test(response = hours, mu = 0)
   old_way <- t.test(x = gss_tbl$hours, mu = 0) %>%
     broom::glance() %>%
-    dplyr::select(statistic, t_df = parameter, p_value = p.value, 
+    dplyr::select(statistic, t_df = parameter, p_value = p.value,
                   alternative, lower_ci = conf.low, upper_ci = conf.high)
-  
+
   expect_equal(new_way, new_way_alt, tolerance = 1e-5)
   expect_equal(new_way, old_way, tolerance = 1e-5)
 })
 
 test_that("chisq_test works", {
   # maleependence
-  expect_silent(gss_tbl %>% 
+  expect_silent(gss_tbl %>%
                   chisq_test(college ~ partyid))
-  new_way <- gss_tbl %>% 
+  new_way <- gss_tbl %>%
     chisq_test(college ~ partyid)
-  new_way_alt <- gss_tbl %>% 
+  new_way_alt <- gss_tbl %>%
     chisq_test(response = college, explanatory = partyid)
   old_way <- chisq.test(x = table(gss_tbl$partyid, gss_tbl$college)) %>%
     broom::glance() %>%
@@ -58,24 +58,24 @@ test_that("chisq_test works", {
 
   expect_equal(new_way, new_way_alt, tolerance = eps)
   expect_equal(new_way, old_way, tolerance = eps)
-  
+
   # Goodness of Fit
-  expect_silent(gss_tbl %>% 
+  expect_silent(gss_tbl %>%
                   chisq_test(response = partyid, p = c(.3, .4, .3)))
-  new_way <- gss_tbl %>% 
+  new_way <- gss_tbl %>%
     chisq_test(partyid ~ NULL, p = c(.3, .4, .3))
-  new_way_alt <- gss_tbl %>% 
+  new_way_alt <- gss_tbl %>%
     chisq_test(response = partyid, p = c(.3, .4, .3))
   old_way <- chisq.test(x = table(gss_tbl$partyid), p = c(.3, .4, .3)) %>%
     broom::glance() %>%
     dplyr::select(statistic, chisq_df = parameter, p_value = p.value)
-  
+
   expect_equal(new_way, new_way_alt, tolerance = 1e-5)
   expect_equal(new_way, old_way, tolerance = 1e-5)
-  
+
   # check that function errors out when response is numeric
   expect_error(chisq_test(x = gss_tbl, response = age, explanatory = partyid))
-  
+
   # check that function errors out when explanatory is numeric
   expect_error(chisq_test(x = gss_tbl, response = partyid, explanatory = age))
 
@@ -103,16 +103,16 @@ test_that("_stat functions work", {
    chisq_stat(partyid ~ NULL)
  obs_stat_way_alt <- gss_tbl %>%
    chisq_stat(response = partyid)
- 
+
  expect_equivalent(dplyr::pull(new_way), obs_stat_way)
  expect_equivalent(dplyr::pull(new_way), obs_stat_way_alt)
- 
+
  # robust to the named vector
  unordered_p <- gss_tbl %>%
    chisq_test(response = partyid, p = c(.2, .3, .5))
  ordered_p <- gss_tbl %>%
    chisq_test(response = partyid, p = c(ind = .2, rep = .3, dem = .5))
- 
+
  expect_equivalent(unordered_p, ordered_p)
 
   # Two sample t
@@ -129,9 +129,9 @@ test_that("_stat functions work", {
     t_stat(hours ~ sex, order = c("male", "female"))
   obs_stat_way_alt <- gss_tbl %>%
     t_stat(response = hours,
-           explanatory = sex, 
+           explanatory = sex,
            order = c("male", "female"))
-  
+
   expect_equivalent(another_way, obs_stat_way)
   expect_equivalent(another_way, obs_stat_way_alt)
 
@@ -145,10 +145,10 @@ test_that("_stat functions work", {
     t_stat(hours ~ NULL)
   obs_stat_way_alt <- gss_tbl %>%
     t_stat(response = hours)
-  
+
   expect_equivalent(another_way, obs_stat_way)
   expect_equivalent(another_way, obs_stat_way_alt)
-  
+
   expect_error(chisq_stat(x = gss_tbl, response = age, explanatory = sex))
   expect_error(chisq_stat(x = gss_tbl, response = sex, explanatory = age))
 })
@@ -156,11 +156,11 @@ test_that("_stat functions work", {
 test_that("conf_int argument works", {
   expect_equal(
     names(
-      gss_tbl %>% 
-        t_test(hours ~ sex, 
+      gss_tbl %>%
+        t_test(hours ~ sex,
                order = c("male", "female"), conf_int = FALSE)
     ),
-    c("statistic", "t_df", "p_value", "alternative"), 
+    c("statistic", "t_df", "p_value", "alternative"),
     tolerance = 1e-5
   )
   expect_equal(
@@ -200,12 +200,12 @@ test_that("conf_int argument works", {
 
   no_var_equal <- gss_tbl_small %>%
     t_stat(hours ~ sex, order = c("female", "male"))
-  
+
   var_equal <- gss_tbl_small %>%
     t_stat(
       hours ~ sex, order = c("female", "male"),
       var.equal = TRUE
-    ) 
+    )
   expect_false(no_var_equal == var_equal)
 
   shortcut_no_var_equal <- gss_tbl_small %>%
@@ -222,18 +222,18 @@ test_that("conf_int argument works", {
 })
 
 # generate some data to test the prop.test wrapper
-df <- data.frame(resp = c(rep("c", 450), 
-                          rep("d", 50), 
-                          rep("c", 400), 
-                          rep("d", 100)), 
+df <- data.frame(resp = c(rep("c", 450),
+                          rep("d", 50),
+                          rep("c", 400),
+                          rep("d", 100)),
                  exp = rep(c("a", "b"), each = 500))
 
 sum_df <- table(df)
 
-bad_df <- data.frame(resp = 1:5, 
+bad_df <- data.frame(resp = 1:5,
                      exp = letters[1:5])
 
-bad_df2 <- data.frame(resp = letters[1:5], 
+bad_df2 <- data.frame(resp = letters[1:5],
                      exp = 1:5)
 
 test_that("two sample prop_test works", {
@@ -241,44 +241,44 @@ test_that("two sample prop_test works", {
   # run the tests with default args
   base <- prop.test(sum_df)
   infer <- prop_test(df, resp ~ exp, order = c("a", "b"))
-  
+
   # check that results are same
-  expect_equal(base[["statistic"]], 
-               infer[["statistic"]], 
+  expect_equal(base[["statistic"]],
+               infer[["statistic"]],
                tolerance = .001)
-  expect_equal(base[["parameter"]], 
+  expect_equal(base[["parameter"]],
                infer[["chisq_df"]])
-  expect_equal(base[["p.value"]], 
+  expect_equal(base[["p.value"]],
                infer[["p_value"]],
                tolerance = .001)
 
   # expect warning for unspecified order
   expect_warning(prop_test(df, resp ~ exp))
-  
+
   # check that the functions respond to "p" in the same way
   base2 <- prop.test(sum_df, p = c(.1, .1))
   infer2 <- prop_test(df, resp ~ exp, order = c("a", "b"), p = c(.1, .1))
-  expect_equal(base2[["statistic"]], 
-               infer2[["statistic"]], 
+  expect_equal(base2[["statistic"]],
+               infer2[["statistic"]],
                tolerance = .001)
-  expect_equal(base2[["parameter"]], 
+  expect_equal(base2[["parameter"]],
                infer2[["chisq_df"]])
-  expect_equal(base2[["p.value"]], 
+  expect_equal(base2[["p.value"]],
                infer2[["p_value"]],
                tolerance = .001)
-  
+
   # check confidence interval argument
   infer3 <- prop_test(df, resp ~ exp, order = c("a", "b"), conf_int = TRUE)
   expect_length(infer3, 6)
   expect_length(infer2, 4)
-  
+
   # check that the order argument changes output
   infer4 <- prop_test(df, resp ~ exp, order = c("b", "a"), conf_int = TRUE)
   expect_equal(infer4[["lower_ci"]], -infer3[["upper_ci"]], tolerance = .001)
-  
+
   expect_error(prop_test(bad_df, resp ~ exp))
   expect_error(prop_test(bad_df2, resp ~ exp))
-  
+
   # check that the success argument changes output
   infer5 <- prop_test(df, resp ~ exp, order = c("a", "b"), success = "d", conf_int = TRUE)
   expect_equal(infer3[["upper_ci"]], -infer5[["lower_ci"]], tolerance = .001)
@@ -291,34 +291,34 @@ df_1 <- df %>%
 sum_df_1 <- table(df_1)
 
 test_that("one sample prop_test works", {
-  
+
   # check that results with default args are the same
   base <- prop.test(sum_df_1)
   infer <- prop_test(df_1, resp ~ NULL, p = .5)
-  expect_equal(base[["statistic"]], 
-               infer[["statistic"]], 
+  expect_equal(base[["statistic"]],
+               infer[["statistic"]],
                tolerance = .001)
-  expect_equal(base[["parameter"]], 
+  expect_equal(base[["parameter"]],
                infer[["chisq_df"]])
-  expect_equal(base[["p.value"]], 
+  expect_equal(base[["p.value"]],
                infer[["p_value"]],
                tolerance = .001)
-  
+
   # check that the functions respond to "p" in the same way
   base2 <- prop.test(sum_df_1, p = .86)
   infer2 <- prop_test(df_1, resp ~ NULL, p = .86)
-  expect_equal(base2[["statistic"]], 
-               infer2[["statistic"]], 
+  expect_equal(base2[["statistic"]],
+               infer2[["statistic"]],
                tolerance = .001)
-  expect_equal(base2[["parameter"]], 
+  expect_equal(base2[["parameter"]],
                infer2[["chisq_df"]])
-  expect_equal(base2[["p.value"]], 
+  expect_equal(base2[["p.value"]],
                infer2[["p_value"]],
                tolerance = .001)
-  
+
   # expect message for unspecified p
   expect_message(prop_test(df_1, resp ~ NULL))
-  
+
   # check that the success argument changes output
   infer3 <- prop_test(df_1, resp ~ NULL, p = .2, success = "c")
   infer4 <- prop_test(df_1, resp ~ NULL, p = .8, success = "d")

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -274,10 +274,14 @@ test_that("two sample prop_test works", {
   
   # check that the order argument changes output
   infer4 <- prop_test(df, resp ~ exp, order = c("b", "a"), conf_int = TRUE)
-  expect_equal(infer4[["lower_ci"]], -infer3[["upper_ci"]])
+  expect_equal(infer4[["lower_ci"]], -infer3[["upper_ci"]], tolerance = .001)
   
   expect_error(prop_test(bad_df, resp ~ exp))
   expect_error(prop_test(bad_df2, resp ~ exp))
+  
+  # check that the success argument changes output
+  infer5 <- prop_test(df, resp ~ exp, order = c("a", "b"), success = "d", conf_int = TRUE)
+  expect_equal(infer3[["upper_ci"]], -infer5[["lower_ci"]], tolerance = .001)
 })
 
 # ...and some data for the one sample wrapper
@@ -314,4 +318,9 @@ test_that("one sample prop_test works", {
   
   # expect message for unspecified p
   expect_message(prop_test(df_1, resp ~ NULL))
+  
+  # check that the success argument changes output
+  infer3 <- prop_test(df_1, resp ~ NULL, p = .2, success = "c")
+  infer4 <- prop_test(df_1, resp ~ NULL, p = .8, success = "d")
+  expect_equal(infer3[["chisq_df"]], infer4[["chisq_df"]], tolerance = .001)
 })


### PR DESCRIPTION
This PR adds a `success` argument to `prop_test()` and closes #343. (More discussion there!)

Also clarifies documentation on >2-sample tests related to arguments being ignored. This was being done already, though the `alternative` column was supplied in output in the >2-sample case (when it is ignored by `stats::prop.test`). 