### PR TITLE
use vdiffr conditionally

### DIFF
--- a/tests/testthat/helper-data.R
+++ b/tests/testthat/helper-data.R
@@ -1,5 +1,10 @@
 set.seed(4242)
 
+expect_doppelganger <- function(title, fig, path = NULL, ...) {
+  testthat::skip_if_not_installed("vdiffr")
+  vdiffr::expect_doppelganger(title, fig, path = path, ...)
+}
+
 eps <- if (capabilities("long.double")) {sqrt(.Machine$double.eps)} else {0.01}
 
 gss_tbl <- tibble::as_tibble(gss) %>%

--- a/tests/testthat/test-shade_confidence_interval.R
+++ b/tests/testthat/test-shade_confidence_interval.R
@@ -1,8 +1,5 @@
 context("shade_confidence_interval")
 
-library(vdiffr)
-
-
 # shade_confidence_interval -----------------------------------------------
 test_that("shade_confidence_interval works", {
   skip_if(getRversion() > "4.0.2")

--- a/tests/testthat/test-shade_p_value.R
+++ b/tests/testthat/test-shade_p_value.R
@@ -1,8 +1,5 @@
 context("shade_p_value")
 
-library(vdiffr)
-
-
 # shade_p_value -----------------------------------------------------------
 test_that("shade_p_value works", {
   skip_if(getRversion() > "4.0.2")

--- a/tests/testthat/test-visualize.R
+++ b/tests/testthat/test-visualize.R
@@ -1,7 +1,6 @@
 context("visualize")
 
 library(dplyr)
-library(vdiffr)
 
 set.seed(42)
 


### PR DESCRIPTION
From BDR to the `vdiffr` maintainers a few weeks ago:

```
...
> Suggested packages should be used conditionally: see §1.1.3.1 of
> 'Writing R Extensions'.  Some of the requirements of vdiffr are hard to
> install on a platform without X11 such as M1 Macs: see the logs at
> https://www.stats.ox.ac.uk/pub/bdr/M1mac/.
>
> In some cases there are other suggested packages not used conditionally:
> you can check all of them by setting environment variable
> _R_CHECK_DEPENDS_ONLY_=true  -- see
> https://cran.r-project.org/doc/manuals/r-devel/R-ints.html#Tools .
>
> Please correct ASAP and before 2021-01-12 to safely retain the package
> on CRAN.
```

From the `vdiffr` maintainers:

```
Hi everyone,

A simple way to make vdiffr usage conditional is to define your own
`expect_doppelganger()` as follows:

expect_doppelganger <- function(title, fig, path = NULL, ...) {
  testthat::skip_if_not_installed("vdiffr")
  vdiffr::expect_doppelganger(title, fig, path = path, ...)
}

You then call `expect_doppelganger()` without the `vdiffr::` prefix.
See https://github.com/lionel-/ggstance/commit/eac216f6.

```

Though `vdiffr` was in our `Suggests:`, we weren't previously using it conditionally. After these changes,

```
devtools::check(env_vars = c(NOT_CRAN = "true", `_R_CHECK_DEPENDS_ONLY_` = "true"))
```

comes back clean for me!