### PR TITLE
add prop argument to rep_slice_sample

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install XQuartz on MacOS
         if: runner.os == 'macOS'
-        run: brew cask install xquartz
+        run: brew install [--cask] xquartz
 
       - name: Install freetype on MacOS
         if: runner.os == 'macOS'

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,9 @@ not supply sufficient information to calculate an observed statistic
 - Implemented the standardized proportion $z$ statistic for one categorical variable
 - Added `two.sided` as an acceptable alias for `two_sided` for the 
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
-more closely resembles `dplyr::slice_sample()` (the function that supersedes
-`dplyr::sample_n()`) (#325)
+- Added a `prop` argument to `rep_slice_sample()` and `rep_sample_n()` as
+an alternative to the `n`/`size` arguments for specifying the proportion
+of rows in the supplied data to sample per replicate (#361)
 - Various bug fixes and improvements to internal consistency
 
 # infer 0.5.4

--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -30,11 +30,19 @@
 #' @examples
 #' library(dplyr)
 #' library(ggplot2)
+#' library(tibble)
 #'
 #' # take 1000 samples of size n = 50, without replacement
 #' slices <- gss %>%
-#'   rep_sample_n(size = 50, reps = 1000)
+#'   rep_slice_sample(n = 50, reps = 1000)
 #'
+#' slices
+#' 
+#' # refer to the sample size as a proportion of the total 
+#' # number of rows with the prop argument
+#' slices <- gss %>%
+#'   rep_slice_sample(prop = .1, reps = 1000)
+#'   
 #' slices
 #'
 #' # compute the proportion of respondents with a college
@@ -53,12 +61,12 @@
 #'   
 #' # sampling with probability weights. Note probabilities are automatically 
 #' # renormalized to sum to 1
-#' library(tibble)
 #' df <- tibble(
 #'   id = 1:5,
 #'   letter = factor(c("a", "b", "c", "d", "e"))
 #' )
-#' rep_sample_n(df, size = 2, reps = 5, prob = c(.5, .4, .3, .2, .1))
+#' 
+#' rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
 #' @export
 rep_sample_n <- function(tbl, size = NULL, replace = FALSE, reps = 1, 
                          prob = NULL, prop = NULL) {

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -5,14 +5,26 @@
 \alias{rep_slice_sample}
 \title{Perform repeated sampling}
 \usage{
-rep_sample_n(tbl, size, replace = FALSE, reps = 1, prob = NULL)
+rep_sample_n(tbl, size, replace = FALSE, reps = 1, prob = NULL, prop = NULL)
 
-rep_slice_sample(.data, n = 1, replace = FALSE, weight_by = NULL, reps = 1)
+rep_slice_sample(
+  .data,
+  n = 1,
+  replace = FALSE,
+  weight_by = NULL,
+  reps = 1,
+  prop = NULL
+)
 }
 \arguments{
 \item{tbl, .data}{Data frame of population from which to sample.}
 
-\item{size, n}{Sample size of each sample.}
+\item{size, n, prop}{\code{size} and \code{n} refer to the sample size of each sample.
+The \code{size} argument to \code{rep_sample_n()} is required (if \code{prop} is not
+supplied), while \code{n} defaults to 1 in \code{rep_slice_sample()}. \code{prop}, an
+argument to both functions, refers to the proportion of rows to sample in
+each sample, and is rounded down in the case that \code{prop * nrow(tbl)} is
+not an integer. Please only supply one of these arguments.}
 
 \item{replace}{Should sampling be with replacement?}
 

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -59,11 +59,19 @@ has a more similar interface to \code{slice_sample()}.
 \examples{
 library(dplyr)
 library(ggplot2)
+library(tibble)
 
 # take 1000 samples of size n = 50, without replacement
 slices <- gss \%>\%
-  rep_sample_n(size = 50, reps = 1000)
+  rep_slice_sample(n = 50, reps = 1000)
 
+slices
+
+# refer to the sample size as a proportion of the total 
+# number of rows with the prop argument
+slices <- gss \%>\%
+  rep_slice_sample(prop = .1, reps = 1000)
+  
 slices
 
 # compute the proportion of respondents with a college
@@ -82,10 +90,10 @@ ggplot(p_hats, aes(x = prop_college)) +
   
 # sampling with probability weights. Note probabilities are automatically 
 # renormalized to sum to 1
-library(tibble)
 df <- tibble(
   id = 1:5,
   letter = factor(c("a", "b", "c", "d", "e"))
 )
-rep_sample_n(df, size = 2, reps = 5, prob = c(.5, .4, .3, .2, .1))
+
+rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
 }

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -5,7 +5,14 @@
 \alias{rep_slice_sample}
 \title{Perform repeated sampling}
 \usage{
-rep_sample_n(tbl, size, replace = FALSE, reps = 1, prob = NULL, prop = NULL)
+rep_sample_n(
+  tbl,
+  size = NULL,
+  replace = FALSE,
+  reps = 1,
+  prob = NULL,
+  prop = NULL
+)
 
 rep_slice_sample(
   .data,

--- a/tests/testthat/test-rep_sample_n.R
+++ b/tests/testthat/test-rep_sample_n.R
@@ -71,6 +71,20 @@ test_that("rep_sample_n is sensitive to the prob argument", {
   expect_true(all(res1$color == "red"))
 })
 
+test_that("rep_sample_n is sensitive to the prop argument", {
+  set.seed(1)
+  res1 <- rep_sample_n(population, size = 1)
+  
+  set.seed(1)
+  res2 <- rep_sample_n(population, prop = .2)
+  
+  set.seed(1)
+  res3 <- rep_sample_n(population, prop = .21)
+  
+  expect_equal(res1, res2)
+  expect_equal(res1, res3)
+})
+
 test_that("rep_sample_n errors with bad arguments", {
   expect_error(
     population %>%
@@ -91,6 +105,21 @@ test_that("rep_sample_n errors with bad arguments", {
     population %>%
       rep_sample_n(size = 2, reps = "a lot")
   )
+  
+  expect_error(
+    rep_sample_n(population, size = 1, prop = .2),
+    "Please supply one of the `size` or `prop` arguments."
+  )
+  
+  expect_error(
+    rep_sample_n(population, prop = 0),
+    "must be a number in the interval \\(0, 1\\]."
+  )
+  
+  expect_error(
+    rep_sample_n(population, prop = 10),
+    "must be a number in the interval \\(0, 1\\]."
+  )
 })
 
 test_that("rep_slice_sample works", {
@@ -101,4 +130,12 @@ test_that("rep_slice_sample works", {
   res2 <- rep_slice_sample(population, n = 2, reps = 5, weight_by = rep(1 / N, N))
 
   expect_equal(res1, res2)
+  
+  set.seed(1)
+  res3 <- rep_sample_n(population, prop = .5, reps = 5, prob = rep(1 / N, N))
+  
+  set.seed(1)
+  res4 <- rep_slice_sample(population, prop = .5, reps = 5, weight_by = rep(1 / N, N))
+  
+  expect_equal(res3, res4)
 })


### PR DESCRIPTION
This PR adds a `prop` argument to `rep_slice_sample()` and `rep_sample_n()` as an alternative to the `n`/`size` arguments for specifying the proportion of rows in the supplied data to sample per replicate.

Closes #361. :-)