### PR TITLE
refactor, implement prop argument in `rep_slice_sample()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 To be released as 0.6.0.
 
+## Breaking changes
+
+- Added a `prop` argument to `rep_slice_sample()` as an alternative to the `n`
+argument for specifying the proportion of rows in the supplied data to sample
+per replicate (#361, #362, #363). This changes order of arguments of
+`rep_slice_sample()` (in order to be more aligned with `dplyr::slice_sample()`)
+which might break code if it didn't use named arguments (like
+`rep_slice_sample(df, 5, TRUE)`). To fix this, use named arguments (like
+`rep_slice_sample(df, 5, replicate = TRUE)`).
+
+## Improvements
+
 - Improved behavioral consistency of `calculate()`. The package will now
    * supply a consistent error when the supplied `stat` argument isn't well-defined
 for the variables specified
@@ -14,9 +26,6 @@ not supply sufficient information to calculate an observed statistic
 - Implemented the standardized proportion $z$ statistic for one categorical variable
 - Added `two.sided` as an acceptable alias for `two_sided` for the 
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
-- Added a `prop` argument to `rep_slice_sample()` as an alternative to the `n` 
-argument for specifying the proportion of rows in the supplied data to sample 
-per replicate (#361, #362, #363)
 - Various bug fixes and improvements to internal consistency
 
 # infer 0.5.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,16 +14,17 @@ not supply sufficient information to calculate an observed statistic
 - Implemented the standardized proportion $z$ statistic for one categorical variable
 - Added `two.sided` as an acceptable alias for `two_sided` for the 
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
-more closely resembles `dplyr::slice_sample()` (the function that supersedes
-`dplyr::sample_n()`) (#325)
+- Added a `prop` argument to `rep_slice_sample()` as an alternative to the `n` 
+argument for specifying the proportion of rows in the supplied data to sample 
+per replicate (#361, #362, #363)
 - Various bug fixes and improvements to internal consistency
 
 # infer 0.5.4
 
 - `rep_sample_n()` no longer errors when supplied a `prob` argument (#279)
 - Added `rep_slice_sample()`, a light wrapper around `rep_sample_n()`, that
-more closely resembles `dplyr::slice_sample()` (the function that supersedes)
-`dplyr::sample_n()` (#325)
+more closely resembles `dplyr::slice_sample()` (the function that supersedes
+`dplyr::sample_n()`) (#325)
 - Added a `success`, `correct`, and `z` argument to `prop_test()` 
 (#343, #347, #353)
 - Implemented observed statistic calculation for the standardized proportion 

--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -8,27 +8,33 @@
 #' distributions—see the examples below!
 #'
 #' @param tbl,.data Data frame of population from which to sample.
-#' @param size,n Sample size of each sample.
-#' @param replace Should sampling be with replacement?
-#' @param reps Number of samples of size n = `size` to take.
+#' @param size,n,prop `size` and `n` refer to the sample size of each sample. 
+#' The `size` argument to `rep_sample_n()` is required, while `n` defaults to 
+#' 1 in `rep_slice_sample()`. `prop`, an argument to `rep_slice_sample()`, 
+#' refers to the proportion of rows to sample in each sample, and is rounded 
+#' down in the case that `prop * nrow(.data)` is not an integer. When using 
+#' `rep_slice_sample()`, please only supply one of `n` or `prop`.
+#' @param replace Should samples be taken with replacement?
+#' @param reps Number of samples to take.
 #' @param prob,weight_by A vector of sampling weights for each of the rows in
-#' `tbl`—must have length equal to `nrow(tbl)`.
+#' `.data`—must have length equal to `nrow(.data)`.
 #'
-#' @return A tibble of size `rep * size` rows corresponding to `reps`
-#'   samples of size `size` from `tbl`, grouped by `replicate`.
+#' @return A tibble of size `reps * n` rows corresponding to `reps`
+#'   samples of size `n` from `.data`, grouped by `replicate`.
 #'
 #' @details The [dplyr::sample_n()] function (to which `rep_sample_n()` was
 #' originally a supplement) has been superseded by [dplyr::slice_sample()].
-#' `rep_slice_sample()` provides a light wrapper around `rep_sample_n()` that
-#' has a more similar interface to `slice_sample()`.
+#' `rep_sample_n()` now provides a light wrapper around `rep_slice_sample()`, 
+#' which has a more similar interface to `slice_sample()`.
 #'
 #' @examples
 #' library(dplyr)
 #' library(ggplot2)
+#' library(tibble)
 #'
 #' # take 1000 samples of size n = 50, without replacement
 #' slices <- gss %>%
-#'   rep_sample_n(size = 50, reps = 1000)
+#'   rep_slice_sample(n = 50, reps = 1000)
 #'
 #' slices
 #'
@@ -48,47 +54,64 @@
 #'   
 #' # sampling with probability weights. Note probabilities are automatically 
 #' # renormalized to sum to 1
-#' library(tibble)
 #' df <- tibble(
 #'   id = 1:5,
 #'   letter = factor(c("a", "b", "c", "d", "e"))
 #' )
-#' rep_sample_n(df, size = 2, reps = 5, prob = c(.5, .4, .3, .2, .1))
+#' 
+#' rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
 #' @export
 rep_sample_n <- function(tbl, size, replace = FALSE, reps = 1, prob = NULL) {
-  check_type(tbl, is.data.frame)
-  check_type(size, is.numeric)
-  check_type(replace, is.logical)
-  check_type(reps, is.numeric)
-  if (!is.null(prob)) {
-    check_type(prob, is.numeric)
-    if (length(prob) != nrow(tbl)) {
-      stop_glue(
-        "The argument `prob` must have length `nrow(tbl)` = {nrow(tbl)}"
-      )
-    }
-  }
-
-  # Generate row indexes for every future replicate (this way it respects
-  # possibility of  `replace = FALSE`)
-  n <- nrow(tbl)
-  i <- unlist(replicate(
-    reps,
-    sample.int(n, size, replace = replace, prob = prob),
-    simplify = FALSE
-  ))
-
-  tbl %>%
-    dplyr::slice(i) %>%
-    dplyr::mutate(replicate = rep(seq_len(reps), each = size)) %>%
-    dplyr::select(replicate, dplyr::everything()) %>%
-    tibble::as_tibble() %>%
-    dplyr::group_by(replicate)
+  rep_slice_sample(.data = tbl, n = size, replace = replace, reps = reps,
+                   weight_by = prob, prop = NULL)
 }
 
 #' @rdname rep_sample_n
 #' @export
 rep_slice_sample <- function(.data, n = 1, replace = FALSE, weight_by = NULL,
-                             reps = 1) {
-  rep_sample_n(.data, n, replace, reps, weight_by)
+                             reps = 1, prop = NULL) {
+  check_type(.data, is.data.frame)
+  check_type(replace, is.logical)
+  check_type(reps, is.numeric)
+  if (!is.null(weight_by)) {
+    check_type(weight_by, is.numeric)
+    if (length(weight_by) != nrow(.data)) {
+      stop_glue(
+        "The argument `weight_by` must have length `nrow(.data)` = {nrow(.data)}"
+      )
+    }
+  }
+  
+  n <- process_slice_n(n, prop, missing(n), nrow(.data))
+  
+  1:reps %>%
+    purrr::map_dfr(
+      ~ .data %>%
+        dplyr::slice_sample(n = n, weight_by = weight_by, replace = replace)
+    ) %>%
+    dplyr::mutate(
+      replicate = rep(1:reps, each = n), 
+      .before = dplyr::everything()
+    ) %>%
+    dplyr::group_by(replicate)
+}
+
+# an internal helper to check relevant arguments and determine the 
+# appropriate sample size. note that `prop` doesn't get passed to
+# rep_sample_n, so will not trigger any of these checks
+process_slice_n <- function(n, prop, missing_n, n_pop) {
+  if (!xor(missing_n, is.null(prop))) {
+    stop_glue("Please supply one of the `n` or `prop` arguments.")
+  }
+  
+  if (!missing_n) {
+    check_type(n, is.numeric)
+    return(n)
+  }
+    
+  check_type(prop, is.numeric)
+  if (prop > 1 || prop <= 0) {
+    stop_glue("The `prop` argument must be a number in the interval (0, 1].")
+  }
+  return(floor(n_pop * prop))
 }

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -7,23 +7,35 @@
 \usage{
 rep_sample_n(tbl, size, replace = FALSE, reps = 1, prob = NULL)
 
-rep_slice_sample(.data, n = 1, replace = FALSE, weight_by = NULL, reps = 1)
+rep_slice_sample(
+  .data,
+  n = 1,
+  replace = FALSE,
+  weight_by = NULL,
+  reps = 1,
+  prop = NULL
+)
 }
 \arguments{
 \item{tbl, .data}{Data frame of population from which to sample.}
 
-\item{size, n}{Sample size of each sample.}
+\item{size, n, prop}{\code{size} and \code{n} refer to the sample size of each sample.
+The \code{size} argument to \code{rep_sample_n()} is required, while \code{n} defaults to
+1 in \code{rep_slice_sample()}. \code{prop}, an argument to \code{rep_slice_sample()},
+refers to the proportion of rows to sample in each sample, and is rounded
+down in the case that \code{prop * nrow(.data)} is not an integer. When using
+\code{rep_slice_sample()}, please only supply one of \code{n} or \code{prop}.}
 
-\item{replace}{Should sampling be with replacement?}
+\item{replace}{Should samples be taken with replacement?}
 
-\item{reps}{Number of samples of size n = \code{size} to take.}
+\item{reps}{Number of samples to take.}
 
 \item{prob, weight_by}{A vector of sampling weights for each of the rows in
-\code{tbl}—must have length equal to \code{nrow(tbl)}.}
+\code{.data}—must have length equal to \code{nrow(.data)}.}
 }
 \value{
-A tibble of size \code{rep * size} rows corresponding to \code{reps}
-samples of size \code{size} from \code{tbl}, grouped by \code{replicate}.
+A tibble of size \code{reps * n} rows corresponding to \code{reps}
+samples of size \code{n} from \code{.data}, grouped by \code{replicate}.
 }
 \description{
 These functions extend the functionality of \code{\link[dplyr:sample_n]{dplyr::sample_n()}} and
@@ -34,16 +46,17 @@ distributions—see the examples below!
 \details{
 The \code{\link[dplyr:sample_n]{dplyr::sample_n()}} function (to which \code{rep_sample_n()} was
 originally a supplement) has been superseded by \code{\link[dplyr:slice]{dplyr::slice_sample()}}.
-\code{rep_slice_sample()} provides a light wrapper around \code{rep_sample_n()} that
-has a more similar interface to \code{slice_sample()}.
+\code{rep_sample_n()} now provides a light wrapper around \code{rep_slice_sample()},
+which has a more similar interface to \code{slice_sample()}.
 }
 \examples{
 library(dplyr)
 library(ggplot2)
+library(tibble)
 
 # take 1000 samples of size n = 50, without replacement
 slices <- gss \%>\%
-  rep_sample_n(size = 50, reps = 1000)
+  rep_slice_sample(n = 50, reps = 1000)
 
 slices
 
@@ -63,10 +76,10 @@ ggplot(p_hats, aes(x = prop_college)) +
   
 # sampling with probability weights. Note probabilities are automatically 
 # renormalized to sum to 1
-library(tibble)
 df <- tibble(
   id = 1:5,
   letter = factor(c("a", "b", "c", "d", "e"))
 )
-rep_sample_n(df, size = 2, reps = 5, prob = c(.5, .4, .3, .2, .1))
+
+rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
 }

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -9,22 +9,23 @@ rep_sample_n(tbl, size, replace = FALSE, reps = 1, prob = NULL)
 
 rep_slice_sample(
   .data,
-  n = 1,
+  n = NULL,
+  prop = NULL,
   replace = FALSE,
   weight_by = NULL,
-  reps = 1,
-  prop = NULL
+  reps = 1
 )
 }
 \arguments{
 \item{tbl, .data}{Data frame of population from which to sample.}
 
 \item{size, n, prop}{\code{size} and \code{n} refer to the sample size of each sample.
-The \code{size} argument to \code{rep_sample_n()} is required, while \code{n} defaults to
-1 in \code{rep_slice_sample()}. \code{prop}, an argument to \code{rep_slice_sample()},
-refers to the proportion of rows to sample in each sample, and is rounded
-down in the case that \code{prop * nrow(.data)} is not an integer. When using
-\code{rep_slice_sample()}, please only supply one of \code{n} or \code{prop}.}
+The \code{size} argument to \code{rep_sample_n()} is required, while in
+\code{rep_slice_sample()} sample size defaults to 1 if not specified. \code{prop}, an
+argument to \code{rep_slice_sample()}, refers to the proportion of rows to sample
+in each sample, and is rounded down in the case that \code{prop * nrow(.data)} is
+not an integer. When using \code{rep_slice_sample()}, please only supply one of
+\code{n} or \code{prop}.}
 
 \item{replace}{Should samples be taken with replacement?}
 
@@ -44,10 +45,18 @@ This operation is especially helpful while creating sampling
 distributions—see the examples below!
 }
 \details{
-The \code{\link[dplyr:sample_n]{dplyr::sample_n()}} function (to which \code{rep_sample_n()} was
-originally a supplement) has been superseded by \code{\link[dplyr:slice]{dplyr::slice_sample()}}.
-\code{rep_sample_n()} now provides a light wrapper around \code{rep_slice_sample()},
-which has a more similar interface to \code{slice_sample()}.
+\code{rep_sample_n()} and \code{rep_slice_sample()} are designed to behave similar to
+their dplyr counterparts. As such, they have at least the following
+differences:
+\itemize{
+\item In case \code{replace = FALSE} having \code{size} bigger than number of data rows in
+\code{rep_sample_n()} will give an error. In \code{rep_slice_sample()} having such \code{n}
+or \code{prop > 1} will give warning and output sample size will be set to number
+of rows in data.
+}
+
+Note that the \code{\link[dplyr:sample_n]{dplyr::sample_n()}} function  has been superseded by
+\code{\link[dplyr:slice]{dplyr::slice_sample()}}.
 }
 \examples{
 library(dplyr)
@@ -73,8 +82,8 @@ ggplot(p_hats, aes(x = prop_college)) +
     x = "p_hat", y = "Number of samples",
     title = "Sampling distribution of p_hat"
   )
-  
-# sampling with probability weights. Note probabilities are automatically 
+
+# sampling with probability weights. Note probabilities are automatically
 # renormalized to sum to 1
 df <- tibble(
   id = 1:5,

--- a/tests/testthat/test-rep_sample_n.R
+++ b/tests/testthat/test-rep_sample_n.R
@@ -1,147 +1,303 @@
 context("rep_sample_n")
 
-N <- 5
+n_population <- 5
 population <- tibble::tibble(
-  ball_id = 1:N,
-  color = factor(c(rep("red", 3), rep("white", N - 3)))
+  ball_id = 1:n_population,
+  color = factor(c(rep("red", 3), rep("white", n_population - 3)))
 )
 
-test_that("rep_sample_n is sensitive to the size argument", {
-  set.seed(1)
-  reps <- 10
-  s1 <- 2
-  s2 <- 3
 
-  res1 <- population %>% rep_sample_n(size = s1, reps = reps)
-  res2 <- population %>% rep_sample_n(size = s2, reps = reps)
-
-  expect_equal(ncol(res1), ncol(res2))
-  expect_equal(ncol(res1), 3)
-
-  expect_equal(nrow(res1) / s1, nrow(res2) / s2)
-  expect_equal(nrow(res1), reps * s1)
+# rep_sample_n ------------------------------------------------------------
+test_that("`rep_sample_n` works", {
+  out <- rep_sample_n(population, size = 2, reps = 5)
+  expect_equal(nrow(out), 2 * 5)
+  expect_equal(colnames(out), c("replicate", colnames(population)))
+  expect_true(dplyr::is_grouped_df(out))
 })
 
-test_that("rep_sample_n is sensitive to the reps argument", {
-  set.seed(1)
-  r1 <- 10
-  r2 <- 5
-  size <- 2
+test_that("`rep_sample_n` checks input", {
+  # `tbl`
+  expect_error(rep_sample_n("a", size = 1), "`tbl`.*'data.frame'")
 
-  res1 <- population %>% rep_sample_n(size = size, reps = r1)
-  res2 <- population %>% rep_sample_n(size = size, reps = r2)
+  # `size`
+  expect_error(rep_sample_n(population, size = "a"), "`size`.*number")
+  expect_error(rep_sample_n(population, size = 1:2), "`size`.*single")
+  expect_error(rep_sample_n(population, size = -1), "`size`.*non-negative")
 
-  expect_equal(ncol(res1), ncol(res2))
-  expect_equal(ncol(res1), 3)
+  # `replace`
+  expect_error(
+    rep_sample_n(population, size = 1, replace = "a"),
+    "`replace`.*'TRUE or FALSE'"
+  )
 
-  expect_equal(nrow(res1) / r1, nrow(res2) / r2)
-  expect_equal(nrow(res1), r1 * size)
+  # `reps`
+  expect_error(
+    rep_sample_n(population, size = 1, reps = "a"),
+    "`reps`.*number"
+  )
+  expect_error(
+    rep_sample_n(population, size = 1, reps = 1:2),
+    "`reps`.*single"
+  )
+  expect_error(
+    rep_sample_n(population, size = 1, reps = 0.5),
+    "`reps`.*not less than 1"
+  )
+
+  # `prob`
+  expect_error(
+    rep_sample_n(population, size = 1, prob = "a"),
+    "`prob`.*numeric"
+  )
+  expect_error(
+    rep_sample_n(population, size = 1, prob = c(0.1, 0.9)),
+    glue::glue("`prob`.*length.*{nrow(population)}")
+  )
 })
 
-test_that("rep_sample_n is sensitive to the replace argument", {
+test_that("`rep_sample_n` gives error on big sample size if `replace=FALSE`", {
+  expect_error(
+    rep_sample_n(population, size = n_population * 2),
+    "Use `replace = TRUE`"
+  )
+})
+
+test_that("`rep_sample_n` uses `size`", {
   set.seed(1)
-  res1 <- population %>% rep_sample_n(size = 5, reps = 100, replace = TRUE)
+  out <- rep_sample_n(population, size = 2)
+  expect_equal(nrow(out), 2)
+
+  # `size = 0` is allowed following `dplyr::sample_n()`
+  out <- rep_sample_n(population, size = 0)
+  expect_true(nrow(out) == 0)
+})
+
+test_that("`rep_sample_n` uses `replace`", {
+  set.seed(1)
+  res_repl <- rep_sample_n(population, size = 5, reps = 100, replace = TRUE)
 
   set.seed(1)
-  res2 <- population %>% rep_sample_n(size = 5, reps = 100, replace = FALSE)
+  res_norepl <- rep_sample_n(population, size = 5, reps = 100, replace = FALSE)
 
-  expect_true(all(res1$replicate == res2$replicate))
-  expect_false(all(res1$ball_id == res2$ball_id))
-  expect_false(all(res1$color == res2$color))
-
-  expect_equal(ncol(res1), ncol(res2))
-  expect_equal(ncol(res1), 3)
+  expect_true(all(res_repl[["replicate"]] == res_norepl[["replicate"]]))
+  expect_false(all(res_repl[["ball_id"]] == res_norepl[["ball_id"]]))
+  expect_false(all(res_repl[["color"]] == res_norepl[["color"]]))
 
   # Check if there are actually no duplicates in case `replace = FALSE`
-  no_duplicates <- all(tapply(res2$ball_id, res2$replicate, anyDuplicated) == 0)
+  no_duplicates <- all(
+    tapply(res_norepl$ball_id, res_norepl$replicate, anyDuplicated) == 0
+  )
   expect_true(no_duplicates)
 })
 
-test_that("rep_sample_n is sensitive to the prob argument", {
+test_that("`rep_sample_n` uses `reps`", {
   set.seed(1)
-  res1 <- population %>%
-    rep_sample_n(
-      size = 5,
-      reps = 100,
-      replace = TRUE,
-      prob = c(1, rep(0, 4))
-    )
+  out <- rep_sample_n(population, size = 2, reps = 5)
+  expect_equal(nrow(out), 2 * 5)
+
+  # `size = 0` is allowed even with `reps > 1`
+  out <- rep_sample_n(population, size = 0, reps = 10)
+  expect_true(nrow(out) == 0)
+})
+
+test_that("`rep_sample_n` uses `prob`", {
+  set.seed(1)
+  res1 <- rep_sample_n(
+    population,
+    size = 5,
+    reps = 100,
+    replace = TRUE,
+    prob = c(1, rep(0, n_population - 1))
+  )
 
   expect_true(all(res1$ball_id == 1))
   expect_true(all(res1$color == "red"))
+
+  # `prob` should be automatically normalized
+  set.seed(1)
+  res1 <- rep_sample_n(
+    population,
+    size = n_population,
+    prob = rep(1, n_population)
+  )
+  set.seed(1)
+  res2 <- rep_sample_n(
+    population,
+    size = n_population,
+    prob = rep(1, n_population) / n_population
+  )
+
+  expect_equal(res1[["ball_id"]], res2[["ball_id"]])
 })
 
-test_that("rep_slice_sample is sensitive to the prop argument", {
+
+# rep_slice_sample --------------------------------------------------------
+test_that("`rep_slice_sample` works", {
+  # By default only one row should be sampled
+  out <- rep_slice_sample(population)
+  expect_equal(nrow(out), 1)
+  expect_equal(colnames(out), c("replicate", colnames(population)))
+  expect_true(dplyr::is_grouped_df(out))
+
+  # Using `n` argument
+  out <- rep_slice_sample(population, n = 2, reps = 5)
+  expect_equal(nrow(out), 2 * 5)
+
+  # Using `prop` argument
+  prop <- 2 / n_population
+  out <- rep_slice_sample(population, prop = prop, reps = 5)
+  expect_equal(nrow(out), 2 * 5)
+})
+
+test_that("`rep_slice_sample` checks input", {
+  # `.data`
+  expect_error(rep_slice_sample("a", n = 1), "`.data`.*'data.frame'")
+
+  # `n`
+  expect_error(rep_slice_sample(population, n = "a"), "`n`.*number")
+  expect_error(rep_slice_sample(population, n = 1:2), "`n`.*single")
+  expect_error(rep_slice_sample(population, n = -1), "`n`.*non-negative")
+
+  # `prop`
+  expect_error(rep_slice_sample(population, prop = "a"), "`prop`.*number")
+  expect_error(rep_slice_sample(population, prop = 1:2), "`prop`.*single")
+  expect_error(rep_slice_sample(population, prop = -1), "`prop`.*non-negative")
+
+  # Only one `n` or `prop` should be supplied
+  expect_error(
+    rep_slice_sample(population, n = 1, prop = 0.5),
+    "exactly one.*`n` or `prop`"
+  )
+
+  # `replace`
+  expect_error(
+    rep_slice_sample(population, n = 1, replace = "a"),
+    "`replace`.*'TRUE or FALSE'"
+  )
+
+  # `weight_by`
+  expect_error(
+    rep_slice_sample(population, n = 1, weight_by = "a"),
+    "`weight_by`.*numeric"
+  )
+  expect_error(
+    rep_slice_sample(population, n = 1, weight_by = c(0.1, 0.9)),
+    glue::glue("`weight_by`.*length.*{nrow(population)}")
+  )
+
+  # `reps`
+  expect_error(
+    rep_slice_sample(population, n = 1, reps = "a"),
+    "`reps`.*number"
+  )
+  expect_error(
+    rep_slice_sample(population, n = 1, reps = 1:2),
+    "`reps`.*single"
+  )
+  expect_error(
+    rep_slice_sample(population, n = 1, reps = 0.5),
+    "`reps`.*not less than 1"
+  )
+})
+
+test_that("`rep_slice_sample` warns on big sample size if `replace = FALSE`", {
+  # Using big `n`
+  expect_warning(
+    out <- rep_slice_sample(population, n = n_population * 2, reps = 1),
+    "sample size.*bigger.*number of rows"
+  )
+  expect_true(nrow(out) == n_population)
+
+  # Using big `prop`
+  expect_warning(
+    out <- rep_slice_sample(population, prop = 2, reps = 1),
+    "sample size.*bigger.*number of rows"
+  )
+  expect_true(nrow(out) == n_population)
+})
+
+test_that("`rep_slice_sample` uses `n` and `prop`", {
   set.seed(1)
   res1 <- rep_slice_sample(population, n = 1)
-  
-  set.seed(1)
-  res2 <- rep_slice_sample(population, prop = .2)
-  
-  set.seed(1)
-  res3 <- rep_slice_sample(population, prop = .21)
-  
-  expect_equal(res1, res2)
-  expect_equal(res1, res3)
-})
-
-test_that("rep_sample_n errors with bad arguments", {
-  expect_error(
-    population %>%
-      rep_sample_n(size = 2, reps = 10, prob = rep(x = 1 / 5, times = 100))
-  )
-
-  expect_error(
-    population %>%
-      rep_sample_n(size = 2, reps = 10, prob = c(1 / 2, 1 / 2))
-  )
-
-  expect_error(
-    population %>%
-      rep_sample_n(size = "a lot", reps = 10)
-  )
-
-  expect_error(
-    population %>%
-      rep_sample_n(size = 2, reps = "a lot")
-  )
-  
-  expect_error(
-    rep_slice_sample(population, n = 1, prop = .2),
-    "Please supply one of the `n` or `prop` arguments."
-  )
-  
-  expect_error(
-    rep_slice_sample(population, prop = 0),
-    "must be a number in the interval \\(0, 1\\]."
-  )
-  
-  expect_error(
-    rep_slice_sample(population, prop = 10),
-    "must be a number in the interval \\(0, 1\\]."
-  )
-  
-  expect_error(
-    rep_sample_n(population, prop = .1),
-    "unused argument \\(prop = 0.1\\)"
-  )
-})
-
-test_that("rep_slice_sample works", {
-  set.seed(1)
-  res1 <- rep_sample_n(population, size = 2, reps = 5, prob = rep(1 / N, N))
 
   set.seed(1)
-  res2 <- rep_slice_sample(population, n = 2, reps = 5, weight_by = rep(1 / N, N))
+  res2 <- rep_slice_sample(population, prop = 1 / n_population)
 
   expect_equal(res1, res2)
-  
+
+  # Output sample size is rounded down when using `prop`
   set.seed(1)
-  res3 <- rep_sample_n(population, size = floor(nrow(population)/2), 
-                       reps = 5, prob = rep(1 / N, N))
-  
+  res3 <- rep_slice_sample(population, prop = 1.5 / n_population)
+
+  expect_equal(res2, res3)
+
+  # `n = 0` is allowed
+  out <- rep_slice_sample(population, n = 0)
+  expect_equal(nrow(out), 0)
+
+  # `prop = 0` is allowed
+  out <- rep_slice_sample(population, prop = 0)
+  expect_equal(nrow(out), 0)
+})
+
+test_that("`rep_slice_sample` uses `replace`", {
   set.seed(1)
-  res4 <- rep_slice_sample(population, prop = .5, reps = 5, weight_by = rep(1 / N, N))
-  
-  expect_equal(res3, res4)
+  res_repl <- rep_slice_sample(population, n = 5, reps = 100, replace = TRUE)
+
+  set.seed(1)
+  res_norepl <- rep_slice_sample(population, n = 5, reps = 100, replace = FALSE)
+
+  expect_true(all(res_repl[["replicate"]] == res_norepl[["replicate"]]))
+  expect_false(all(res_repl[["ball_id"]] == res_norepl[["ball_id"]]))
+  expect_false(all(res_repl[["color"]] == res_norepl[["color"]]))
+
+  # Check if there are actually no duplicates in case `replace = FALSE`
+  no_duplicates <- all(
+    tapply(res_norepl$ball_id, res_norepl$replicate, anyDuplicated) == 0
+  )
+  expect_true(no_duplicates)
+})
+
+test_that("`rep_slice_sample` uses `weight_by`", {
+  set.seed(1)
+  res1 <- rep_slice_sample(
+    population,
+    n = 5,
+    reps = 100,
+    replace = TRUE,
+    weight_by = c(1, rep(0, n_population - 1))
+  )
+
+  expect_true(all(res1$ball_id == 1))
+  expect_true(all(res1$color == "red"))
+
+  # `weight_by` should be automatically normalized
+  set.seed(1)
+  res1 <- rep_slice_sample(
+    population,
+    n = n_population,
+    weight_by = rep(1, n_population)
+  )
+  set.seed(1)
+  res2 <- rep_slice_sample(
+    population,
+    n = n_population,
+    weight_by = rep(1, n_population) / n_population
+  )
+
+  expect_equal(res1[["ball_id"]], res2[["ball_id"]])
+})
+
+test_that("`rep_slice_sample` uses `reps`", {
+  set.seed(1)
+  out <- rep_slice_sample(population, n = 2, reps = 5)
+  expect_equal(nrow(out), 2 * 5)
+
+  # `n = 0` is allowed even with `reps > 1`
+  out <- rep_slice_sample(population, n = 0, reps = 10)
+  expect_true(nrow(out) == 0)
+
+  # `prop = 0` is allowed even with `reps > 1`
+  out <- rep_slice_sample(population, prop = 0, reps = 10)
+  expect_true(nrow(out) == 0)
 })

--- a/tests/testthat/test-rep_sample_n.R
+++ b/tests/testthat/test-rep_sample_n.R
@@ -71,6 +71,20 @@ test_that("rep_sample_n is sensitive to the prob argument", {
   expect_true(all(res1$color == "red"))
 })
 
+test_that("rep_slice_sample is sensitive to the prop argument", {
+  set.seed(1)
+  res1 <- rep_slice_sample(population, n = 1)
+  
+  set.seed(1)
+  res2 <- rep_slice_sample(population, prop = .2)
+  
+  set.seed(1)
+  res3 <- rep_slice_sample(population, prop = .21)
+  
+  expect_equal(res1, res2)
+  expect_equal(res1, res3)
+})
+
 test_that("rep_sample_n errors with bad arguments", {
   expect_error(
     population %>%
@@ -91,6 +105,26 @@ test_that("rep_sample_n errors with bad arguments", {
     population %>%
       rep_sample_n(size = 2, reps = "a lot")
   )
+  
+  expect_error(
+    rep_slice_sample(population, n = 1, prop = .2),
+    "Please supply one of the `n` or `prop` arguments."
+  )
+  
+  expect_error(
+    rep_slice_sample(population, prop = 0),
+    "must be a number in the interval \\(0, 1\\]."
+  )
+  
+  expect_error(
+    rep_slice_sample(population, prop = 10),
+    "must be a number in the interval \\(0, 1\\]."
+  )
+  
+  expect_error(
+    rep_sample_n(population, prop = .1),
+    "unused argument \\(prop = 0.1\\)"
+  )
 })
 
 test_that("rep_slice_sample works", {
@@ -101,4 +135,13 @@ test_that("rep_slice_sample works", {
   res2 <- rep_slice_sample(population, n = 2, reps = 5, weight_by = rep(1 / N, N))
 
   expect_equal(res1, res2)
+  
+  set.seed(1)
+  res3 <- rep_sample_n(population, size = floor(nrow(population)/2), 
+                       reps = 5, prob = rep(1 / N, N))
+  
+  set.seed(1)
+  res4 <- rep_slice_sample(population, prop = .5, reps = 5, weight_by = rep(1 / N, N))
+  
+  expect_equal(res3, res4)
 })


### PR DESCRIPTION
Much better!☃️

This PR adds a `prop` argument to `rep_slice_sample()` as an alternative to the `n`  argument for specifying the proportion of rows in the supplied data to sample per replicate and simplifies the `rep_sample_n` and `rep_slice_sample` internals significantly.

Continuing discussion from #362, making use of `dplyr::slice_sample()` more straightforwardly, I'm not sure we need to wrap `dplyr::sample_n` and `dplyr::slice_sample` separately. This implementation makes `rep_sample_n` a wrapper around `rep_slice_sample` that ignores the `prop` argument, and otherwise doesn't need to introduce any more complexity to handle arguments appropriately.

The `missing_n` argument in `process_slice_n` allows the user to pass the `prop` argument while leaving the default `n = 1` in `rep_slice_sample`.

Closes #361, closes #363.