### PR TITLE
Update observed_stat_examples.Rmd

### DIFF
--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -1039,7 +1039,7 @@ Finding the observed statistic,
 ```{r}
 t_hat <- gss %>% 
   specify(response = hours) %>%
-  hypothesize(null = "point", mu = 40) %>%
+  hypothesize(null = "point", mu = 40) %>% # I'm a little bit confused why there is a hypothesize step when we want to get a confidence interval
   calculate(stat = "t")
 ```
 
@@ -1057,7 +1057,7 @@ Then, generating the null distribution,
 ```{r}
 boot <- gss %>%
    specify(response = hours) %>%
-   hypothesize(null = "point", mu = 40) %>%
+   hypothesize(null = "point", mu = 40) %>% # the same as here
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "t")
 ```
@@ -1082,7 +1082,7 @@ standard_error_ci <- boot %>%
   get_ci(type = "se", point_estimate = t_hat)
 
 visualize(boot) +
-  shade_confidence_interval(endpoints = standard_error_ci)
+  shade_confidence_interval(endpoints = standard_error_ci) # this result is much different to the previous percentile's one
 ```
 
 


### PR DESCRIPTION
Hello. I'm a little bit confused about this example: why we need a hypothesize step when we want to get a confidence interval? (please see the code) 

And the results of this example seem to be incorrect: the `standard_error_ci` is too much different from the `percentile_ci`.

Actually, if we comment out the hypothesize step, the results would seem to be reasonable:

``` r
library(infer)
# load in the dataset
data(gss)

t_hat <- gss %>% 
  specify(response = hours) %>%
  # hypothesize(null = "point", mu = 40) %>%
  calculate(stat = "t")
#> Warning: A t statistic requires a null hypothesis to calculate the observed statistic. 
#> Output assumes the following null value: `mu = 0`.

boot <- gss %>%
   specify(response = hours) %>%
   # hypothesize(null = "point", mu = 40) %>%
   generate(reps = 1000, type = "bootstrap") %>%
   calculate(stat = "t")
#> Warning: A t statistic requires a null hypothesis to calculate the observed statistic. 
#> Output assumes the following null value: `mu = 0`.

percentile_ci <- get_ci(boot)

visualize(boot) +
  shade_confidence_interval(endpoints = percentile_ci)
```

![](https://i.imgur.com/4Eu3xfR.png)

``` r
standard_error_ci <- boot %>%
  get_ci(type = "se", point_estimate = t_hat)

visualize(boot) +
  shade_confidence_interval(endpoints = standard_error_ci)
```

![](https://i.imgur.com/ObqUhHL.png)

<sup>Created on 2021-03-22 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>