### PR TITLE
fix calculate error when columns are named `x`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ not supply sufficient information to calculate an observed statistic
 - Implemented the standardized proportion $z$ statistic for one categorical variable
 - Added `two.sided` as an acceptable alias for `two_sided` for the 
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
+- Fixed bug in `calculate()` for `stat = "t"` to allow for handling
+columns named `x`
 - Various bug fixes and improvements to internal consistency
 
 ## Other

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -419,7 +419,7 @@ calc_impl.t <- function(type, x, order, ...) {
         dplyr::summarize(
           stat = stats::t.test(
             !!response_expr(x),
-            mu = attr(x, "params"),
+            mu = attr(!!x, "params"),
             ...
           )[["statistic"]]
         )

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -622,9 +622,16 @@ test_that("calculate can handle variables named x", {
       calculate(stat = "t")
   })
   
+  expect_silent({
+    t_1 <- data.frame(sample = 1:10) %>% 
+      specify(response = sample) %>% 
+      hypothesise(null = "point", mu = 0) %>% 
+      calculate(stat = "t")
+  })
+  
   expect_equal(
     unname(t_0$stat),
-    5.74,
+    unname(t_1$stat),
     tolerance = .001
   )
 })

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -613,3 +613,18 @@ test_that("calculate messages informatively with excessive null", {
     "point null hypothesis `sigma = 10` does not inform calculation"
   )
 })
+
+test_that("calculate can handle variables named x", {
+  expect_silent({
+    t_0 <- data.frame(x = 1:10) %>% 
+      specify(response = x) %>% 
+      hypothesise(null = "point", mu = 0) %>% 
+      calculate(stat = "t")
+  })
+  
+  expect_equal(
+    unname(t_0$stat),
+    5.74,
+    tolerance = .001
+  )
+})


### PR DESCRIPTION
#370 was due to to the fact that dplyr evaluates `attr(x, "params")` in reference to the column `x` in `.data` rather than the `x` in `calc_impl.t`'s environment. This came up inside of `calc_impl.t`, though I checked for similar usages in other `calc_impl` methods and couldn't find any. This fixes the issue, adds a small test, and updates NEWS.🦥

Closes #370.