### PR TITLE
correct `theory_type` on `stat = "diff in props"` w factor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ not supply sufficient information to calculate an observed statistic
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
 - Fixed bug in `calculate()` for `stat = "t"` to allow for handling
 columns named `x`
+- Fixed bug in `shade_p_value` where the package would erroneously warn when
+  `stat = "diff in props"` and one of the variables was a factor with more than
+  two levels.
 - Various bug fixes and improvements to internal consistency
 
 ## Other

--- a/R/set_params.R
+++ b/R/set_params.R
@@ -83,8 +83,8 @@ set_params <- function(x) {
       # Two sample proportions (z distribution)
       # Parameter(s) not needed since standard normal
       if (
-        (length(levels(response_variable(x))) == 2) &
-        (length(levels(explanatory_variable(x))) == 2)
+        (length(unique(response_variable(x))) == 2) &
+        (length(unique(explanatory_variable(x))) == 2)
       ) {
         attr(x, "theory_type") <- "Two sample props z"
       } else {


### PR DESCRIPTION
Closes #374. :-) 

``` r
library(tidyverse)
library(infer)
data(gss)

# partyid coded as factor

gss_rd <- gss %>%  filter(partyid %in% c("rep", "dem"))

class(gss_rd$partyid)
#> [1] "factor"

gss_null<-gss_rd %>% specify(college ~ partyid, success = "degree") %>%
  hypothesize(null = "independence") %>% 
  generate(reps = 1000, type = "permute") %>% 
  calculate(stat = "diff in props", order = c("rep", "dem")) 

gss_stat <- gss_rd %>% specify(college ~ partyid, success = "degree") %>%
  calculate(stat = "diff in props", order = c("rep", "dem")) 

gss_null %>% visualise()+shade_p_value(obs_stat = gss_stat, direction = "both")
```

![](https://i.imgur.com/Q8awSE3.png)

``` r
# ...or as character
gss_rd <- gss %>%  filter(partyid %in% c("rep", "dem")) %>% mutate(partyid = as.character(partyid) )

class(gss_rd$partyid)
#> [1] "character"

gss_null<-gss_rd %>% specify(college ~ partyid, success = "degree") %>%
  hypothesize(null = "independence") %>% 
  generate(reps = 1000, type = "permute") %>% 
  calculate(stat = "diff in props", order = c("rep", "dem")) 

gss_stat <- gss_rd %>% specify(college ~ partyid, success = "degree") %>%
  calculate(stat = "diff in props", order = c("rep", "dem")) 

gss_null %>% visualise()+shade_p_value(obs_stat = gss_stat, direction = "both")
```

![](https://i.imgur.com/N8nKTiY.png)

<sup>Created on 2021-04-03 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9001)</sup>