### PR TITLE
improve handling of unused factor levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,9 +28,8 @@ not supply sufficient information to calculate an observed statistic
 `direction` argument in `get_p_value()` and `shade_p_value()` (#355)
 - Fixed bug in `calculate()` for `stat = "t"` to allow for handling
 columns named `x`
-- Fixed bug in `shade_p_value` where the package would erroneously warn when
-  `stat = "diff in props"` and one of the variables was a factor with more than
-  two levels.
+- Fixed several bugs related to factors with unused levels (#374, #375, 
+#397, #380).
 - Update `calculate()` to allow lowercase aliases for `stat` argument (#373).
 - Various bug fixes and improvements to internal consistency
 

--- a/R/set_params.R
+++ b/R/set_params.R
@@ -7,7 +7,7 @@ set_params <- function(x) {
   attr(x, "theory_type") <- NULL
   
   if (has_response(x)) {
-    num_response_levels <- length(levels(response_variable(x)))
+    num_response_levels <- length(unique(response_variable(x)))
   }
   
   # One variable
@@ -53,7 +53,7 @@ set_params <- function(x) {
     ) {
       
       # Two sample means (t distribution)
-      if (length(levels(explanatory_variable(x))) == 2) {
+      if (length(unique(explanatory_variable(x))) == 2) {
         attr(x, "theory_type") <- "Two sample t"
         # Keep track of Satterthwaite degrees of freedom since lost when
         # in aggregation w/ calculate()/generate()

--- a/R/set_params.R
+++ b/R/set_params.R
@@ -16,7 +16,7 @@ set_params <- function(x) {
     )
   }
   
-  if (has_response(x)) {
+  if (has_explanatory(x)) {
     num_explanatory_levels <- length(unique(explanatory_variable(x)))
     
     check_factor_levels(
@@ -132,7 +132,7 @@ set_params <- function(x) {
 
 check_factor_levels <- function(x, type, name) {
   if (is.factor(x)) {
-    unused <- levels(x)[!levels(x) %in% unique(x)]
+    unused <- setdiff(levels(x), unique(x))
     
     if (length(unused) > 0) {
       message_glue(

--- a/R/set_params.R
+++ b/R/set_params.R
@@ -8,6 +8,22 @@ set_params <- function(x) {
   
   if (has_response(x)) {
     num_response_levels <- length(unique(response_variable(x)))
+    
+    check_factor_levels(
+      response_variable(x), 
+      "response", 
+      response_name(x)
+    )
+  }
+  
+  if (has_response(x)) {
+    num_explanatory_levels <- length(unique(explanatory_variable(x)))
+    
+    check_factor_levels(
+      explanatory_variable(x), 
+      "explanatory", 
+      explanatory_name(x)
+    )
   }
   
   # One variable
@@ -53,7 +69,7 @@ set_params <- function(x) {
     ) {
       
       # Two sample means (t distribution)
-      if (length(unique(explanatory_variable(x))) == 2) {
+      if (num_explanatory_levels == 2) {
         attr(x, "theory_type") <- "Two sample t"
         # Keep track of Satterthwaite degrees of freedom since lost when
         # in aggregation w/ calculate()/generate()
@@ -83,8 +99,8 @@ set_params <- function(x) {
       # Two sample proportions (z distribution)
       # Parameter(s) not needed since standard normal
       if (
-        (length(unique(response_variable(x))) == 2) &
-        (length(unique(explanatory_variable(x))) == 2)
+        (num_response_levels == 2) &
+        (num_explanatory_levels == 2)
       ) {
         attr(x, "theory_type") <- "Two sample props z"
       } else {
@@ -112,4 +128,17 @@ set_params <- function(x) {
   }
 
   x
+}
+
+check_factor_levels <- function(x, type, name) {
+  if (is.factor(x)) {
+    unused <- levels(x)[!levels(x) %in% unique(x)]
+    
+    if (length(unused) > 0) {
+      message_glue(
+        "Dropping unused factor levels {list(unused)} from the ",
+        "supplied {type} variable '{name}'."
+      )
+    }
+  }
 }

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -86,3 +86,12 @@ test_that("is_complete works", {
 test_that("specify doesn't have NSE issues (#256)", {
   expect_silent(specify(tibble(x = 1:10), x ~ NULL))
 })
+
+test_that("specify messages when dropping unused levels", {
+  expect_message(
+    gss %>%  
+      dplyr::filter(partyid %in% c("rep", "dem")) %>%
+      specify(age ~ partyid),
+    "Dropping unused factor levels c\\(\"ind\", \"other\""
+  )
+})

--- a/tests/testthat/test-specify.R
+++ b/tests/testthat/test-specify.R
@@ -94,4 +94,24 @@ test_that("specify messages when dropping unused levels", {
       specify(age ~ partyid),
     "Dropping unused factor levels c\\(\"ind\", \"other\""
   )
+  
+  expect_message(
+    gss %>%  
+      dplyr::filter(partyid %in% c("rep", "dem")) %>%
+      specify(partyid ~ age),
+    "Dropping unused factor levels c\\(\"ind\", \"other\""
+  )
+  
+  expect_message(
+    gss %>%  
+      dplyr::filter(partyid %in% c("rep", "dem")) %>%
+      specify(partyid ~ NULL),
+    "Dropping unused factor levels c\\(\"ind\", \"other\""
+  )
+  
+  expect_silent(
+    gss %>%  
+      dplyr::filter(partyid %in% c("rep", "dem")) %>%
+      specify(age ~ NULL)
+  )
 })


### PR DESCRIPTION
Switches from `length(levels())` to `length(unique())` when determining the number of levels in factors and messages on dropped factor levels!

``` r
library(infer)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

gss %>%  
  filter(partyid %in% c("rep", "dem")) %>%
  specify(age ~ partyid) %>%
  calculate(stat = "t", order = c("dem", "rep"))
#> Dropping unused factor levels c("ind", "other", "DK") from the supplied explanatory variable 'partyid'.
#> # A tibble: 1 x 1
#>    stat
#>   <dbl>
#> 1 0.782
```

<sup>Created on 2021-04-14 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9001)</sup>

Closes #379. :-)