### PR TITLE
Fix macOS build on GHA

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -27,80 +27,58 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
+        id: install-r
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: Install XQuartz on MacOS
-        if: runner.os == 'macOS'
-        run: brew install xquartz
-
-      - name: Install freetype on MacOS
-        if: runner.os == 'macOS'
+      - name: Install pak and query dependencies
         run: |
-          brew install freetype
-          brew link --overwrite freetype
-          
-      - name: Install cairo on MacOS for xml2
-        if: runner.os == 'macOS'
-        run: |
-          brew install cairo
-          
-      - name: Install XML2 on MacOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install libxml2
-          brew link --force libxml2
-          xml2-config --cflags
-          
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          install.packages('devtools')
-          install.packages('systemfonts')
-          install.packages('gdtools')
-          install.packages('vdiffr')
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
+          saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
         shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - name: Restore R package cache
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
+          restore-keys: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo add-apt-repository ppa:cran/libgit2
-          echo $sysreqs
-          sudo -s eval "$sysreqs"
+          pak::local_system_requirements(execute = TRUE)
+          pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
+        shell: Rscript {0}
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
+          pak::local_install_dev_deps(upgrade = TRUE)
+          pak::pkg_install("rcmdcheck")
         shell: Rscript {0}
         
       - name: Install MacOS r-devel dependencies
         if: runner.os == 'macOS'
         run: |
-          install.packages('processx')
-          install.packages('ps')
+          pak::pkg_install("processx"")
+          pak::pkg_install("ps"")
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -70,8 +70,8 @@ jobs:
       - name: Install MacOS r-devel dependencies
         if: runner.os == 'macOS'
         run: |
-          pak::pkg_install("processx"")
-          pak::pkg_install("ps"")
+          pak::pkg_install("processx")
+          pak::pkg_install("ps")
         shell: Rscript {0}
 
       - name: Session info


### PR DESCRIPTION
Been seeing:

```
Error in dyn.load(file, DLLpath = DLLpath, ...) : 
  unable to load shared object '/Users/runner/work/_temp/Library/digest/libs/digest.so':
  dlopen(/Users/runner/work/_temp/Library/digest/libs/digest.so, 6): Library not loaded: /Library/Frameworks/R.framework/Versions/4.0/Resources/lib/libR.dylib
  Referenced from: /Users/runner/work/_temp/Library/digest/libs/digest.so
  Reason: image not found
Calls: loadNamespace ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
```

on the macOS GHA builds for a bit now. This PR workshops our package installation in hopes to get that `digest` dependency squared away. :-) 