### PR TITLE
add `fit()` functionality to vignettes

### DIFF
--- a/vignettes/infer.Rmd
+++ b/vignettes/infer.Rmd
@@ -266,4 +266,49 @@ visualize(null_f_distn, method = "both") +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
+### Multiple regression
+
+To accommodate randomization-based inference with multiple explanatory variables, the package implements an alternative workflow based on model fitting. Rather than `calculate()`ing statistics from resampled data, this side of the package allows you to `fit()` linear models on data resampled according to the null hypothesis, supplying model coefficients for each explanatory variable. For the most part, you can just switch out `calculate()` for `fit()` in your `calculate()`-based workflows.
+
+As an example, suppose that we want to fit `hours` worked per week using the respondent `age` and `college` completion status. We could first begin by fitting a linear model to the observed data.
+
+```{r}
+observed_fit <- gss %>%
+  specify(hours ~ age + college) %>%
+  fit()
+```
+
+Now, to generate null distributions for each of these terms, we can fit 1000 models to resamples of the `gss` dataset, where the response `hours` is permuted in each. Note that this code is the same as the above except for the addition of the `hypothesize` and `generate` step.
+
+```{r}
+null_fits <- gss %>%
+  specify(hours ~ age + college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 1000, type = "permute") %>%
+  fit()
+
+null_fits
+```
+
+To permute variables other than the response variable, the `cols` argument to `generate()` allows you to choose any of the `specify()`ed variables to permute independently of each other.
+
+Beyond this point, observed fits and distributions from null fits interface exactly like analogous outputs from `calculate()`. For instance, we can use the following code to calculate a 95% confidence interval from these objects.
+
+```{r}
+get_confidence_interval(
+  null_fits, 
+  point_estimate = observed_fit, 
+  level = .95
+)
+```
+
+Or, we can shade p-values for each of these observed regression coefficients from the observed data.
+
+```{r}
+visualize(null_fits) + 
+  shade_p_value(observed_fit, direction = "both")
+```
+
+### Conclusion
+
 That's it! This vignette covers most all of the key functionality of infer. See `help(package = "infer")` for a full list of functions and vignettes.

--- a/vignettes/infer.Rmd
+++ b/vignettes/infer.Rmd
@@ -175,8 +175,6 @@ null_dist <- gss %>%
   calculate(stat = "mean")
 ```
 
-(Notice the warning: `Removed 1244 rows containing missing values.` This would be worth noting if you were actually carrying out this hypothesis test.)
-
 Our point estimate `r point_estimate` seems *pretty* close to 40, but a little bit different. We might wonder if this difference is just due to random chance, or if the mean number of hours worked per week in the population really isn't 40.
 
 We could initially just visualize the null distribution.

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -1026,6 +1026,8 @@ null_distn %>%
   get_p_value(obs_stat = obs_fit, direction = "two-sided")
 ```
 
+Note that this `fit()`-based workflow can be applied to use cases with differing numbers of explanatory variables and explanatory variable types.
+
 ## Confidence intervals
 
 ### One numerical (one mean)
@@ -1487,3 +1489,53 @@ visualize(boot) +
 ### Two numerical vars - t
 
 Not currently implemented since $t$ could refer to standardized slope or standardized correlation.
+
+### Multiple explanatory variables
+
+Calculating the observed fit,
+
+```{r}
+obs_fit <- gss %>%
+  specify(hours ~ age + college) %>%
+  fit()
+```
+
+Generating a distribution of fits with the response variable permuted,
+
+```{r}
+null_distn <- gss %>%
+  specify(hours ~ age + college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 1000, type = "permute") %>%
+  fit()
+```
+
+Alternatively, generating a distribution of fits where each explanatory variable is permuted independently,
+
+```{r}
+null_distn2 <- gss %>%
+  specify(hours ~ age + college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 1000, type = "permute", cols = c(age, college)) %>%
+  fit()
+```
+
+Calculating confidence intervals from the null fits,
+
+```{r}
+conf_ints <- 
+  get_confidence_interval(
+    null_distn, 
+    level = .95, 
+    point_estimate = obs_fit
+  )
+```
+
+Visualizing the observed fit alongside the null fits,
+
+```{r}
+visualize(null_distn) +
+  shade_confidence_interval(endpoints = conf_ints)
+```
+
+Note that this `fit()`-based workflow can be applied to use cases with differing numbers of explanatory variables and explanatory variable types.

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -982,6 +982,50 @@ null_distn %>%
 
 Not currently implemented since $t$ could refer to standardized slope or standardized correlation.
 
+### Multiple explanatory variables
+
+Calculating the observed fit,
+
+```{r}
+obs_fit <- gss %>%
+  specify(hours ~ age + college) %>%
+  fit()
+```
+
+Generating a distribution of fits with the response variable permuted,
+
+```{r}
+null_distn <- gss %>%
+  specify(hours ~ age + college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 1000, type = "permute") %>%
+  fit()
+```
+
+Generating a distribution of fits where each explanatory variable is permuted independently,
+
+```{r}
+null_distn2 <- gss %>%
+  specify(hours ~ age + college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 1000, type = "permute", cols = c(age, college)) %>%
+  fit()
+```
+
+Visualizing the observed fit alongside the null fits,
+
+```{r}
+visualize(null_distn) +
+  shade_p_value(obs_stat = obs_fit, direction = "two-sided")
+```
+
+Calculating p-values from the null distribution and observed fit,
+
+```{r}
+null_distn %>%
+  get_p_value(obs_stat = obs_fit, direction = "two-sided")
+```
+
 ## Confidence intervals
 
 ### One numerical (one mean)


### PR DESCRIPTION
Some vignette updates following up on #391!

The dropped warning in the `infer.Rmd` vignette is due to an update to the `gss` data that dropped rows without complete cases a release or two ago.