### PR TITLE
implement logistic regression in `fit.infer`

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -16,11 +16,11 @@ generics::fit
 #' [hypothesize()], the function will fit one model. If passed the output 
 #' of [generate()], it will fit a model to each data resample, denoted in 
 #' the `replicate` column. The family of the fitted model depends on the type
-#' of the response variable. If the response is numeric, `fit()` will default
-#' to `family = "gaussian"`. If the response is a 2-level character or
-#' factor, `fit()` will default to `family = "gaussian"`. To fit character or
-#' factor response variables with more than two levels, we recommend 
-#' [parsnip::multinom_reg()].
+#' of the response variable. If the response is numeric, `fit()` will use
+#' `family = "gaussian"` (linear regression). If the response is a 2-level 
+#' factor or character, `fit()` will use `family = "binomial"` (logistic 
+#' regression). To fit character or factor response variables with more than 
+#' two levels, we recommend [parsnip::multinom_reg()].
 #' 
 #' infer provides a fit "method" for infer objects, which is a way of carrying 
 #' out model fitting as applied to infer output. The "generic," imported from

--- a/R/fit.R
+++ b/R/fit.R
@@ -129,7 +129,7 @@ fit.infer <- function(object, mode = "regression", ...) {
           do.call(
             fit_linear_model,
             c(
-              list(object, formula),
+              list(object = data, formula = formula),
               dots
             )
           )
@@ -204,7 +204,7 @@ switch_mode <- function(mode) {
 relevel_response <- function(x) {
   if (!is.null(attr(x, "success"))) {
     x[[response_name(x)]] <- 
-      relevel(
+      stats::relevel(
         response_variable(x), 
         ref = attr(x, "success")
       )

--- a/R/fit.R
+++ b/R/fit.R
@@ -161,7 +161,7 @@ check_family <- function(object, ...) {
   
   if (response_type == "mult") {
     stop_glue(
-      "infer does not support fitting models on categorical response variables ",
+      "infer does not support fitting models for categorical response variables ",
       "with more than two levels. Please see `multinom_reg()` from the ",
       "parsnip package."
     )

--- a/R/fit.R
+++ b/R/fit.R
@@ -11,11 +11,16 @@ generics::fit
 #' 
 #' @description
 #' Given the output of an infer core function, this function will fit
-#' a model using [stats::glm()] according to the formula and data supplied 
+#' a linear model using [stats::glm()] according to the formula and data supplied 
 #' earlier in the pipeline. If passed the output of [specify()] or 
 #' [hypothesize()], the function will fit one model. If passed the output 
 #' of [generate()], it will fit a model to each data resample, denoted in 
-#' the `replicate` column.
+#' the `replicate` column. The family of the fitted model depends on the type
+#' of the response variable. If the response is numeric, `fit()` will default
+#' to `family = "gaussian"`. If the response is a 2-level character or
+#' factor, `fit()` will default to `family = "gaussian"`. To fit character or
+#' factor response variables with more than two levels, we recommend 
+#' [parsnip::multinom_reg()].
 #' 
 #' infer provides a fit "method" for infer objects, which is a way of carrying 
 #' out model fitting as applied to infer output. The "generic," imported from

--- a/R/fit.R
+++ b/R/fit.R
@@ -90,6 +90,11 @@ generics::fit
 #' 
 #' null_fits
 #' 
+#' # for logistic regression, set `mode = "classification"`
+#' gss %>%
+#'   specify(college ~ age + hours) %>%
+#'   fit(mode = "classification")
+#' 
 #' # more in-depth explanation of how to use the infer package
 #' \dontrun{
 #' vignette("infer")

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -4,11 +4,15 @@
 \alias{fit.infer}
 \title{Fit linear models to infer objects}
 \usage{
-\method{fit}{infer}(object, ...)
+\method{fit}{infer}(object, mode = "regression", ...)
 }
 \arguments{
 \item{object}{Output from an infer function---likely \code{\link[=generate]{generate()}} or
 \code{\link[=specify]{specify()}}---which specifies the formula and data to fit a model to.}
+
+\item{mode}{One of "regression" or "classification"---the model type,
+determined by the outcome variable. If a \code{family} argument is passed
+via \code{...}, this argument will be ignored.}
 
 \item{...}{Any optional arguments to pass along to the model fitting
 function. See \code{\link[stats:glm]{stats::glm()}} for more information.}

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -27,11 +27,16 @@ explanatory variable (\code{term}).
 }
 \description{
 Given the output of an infer core function, this function will fit
-a model using \code{\link[stats:glm]{stats::glm()}} according to the formula and data supplied
+a linear model using \code{\link[stats:glm]{stats::glm()}} according to the formula and data supplied
 earlier in the pipeline. If passed the output of \code{\link[=specify]{specify()}} or
 \code{\link[=hypothesize]{hypothesize()}}, the function will fit one model. If passed the output
 of \code{\link[=generate]{generate()}}, it will fit a model to each data resample, denoted in
-the \code{replicate} column.
+the \code{replicate} column. The family of the fitted model depends on the type
+of the response variable. If the response is numeric, \code{fit()} will default
+to \code{family = "gaussian"}. If the response is a 2-level character or
+factor, \code{fit()} will default to \code{family = "gaussian"}. To fit character or
+factor response variables with more than two levels, we recommend
+\code{\link[parsnip:multinom_reg]{parsnip::multinom_reg()}}.
 
 infer provides a fit "method" for infer objects, which is a way of carrying
 out model fitting as applied to infer output. The "generic," imported from

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -4,15 +4,11 @@
 \alias{fit.infer}
 \title{Fit linear models to infer objects}
 \usage{
-\method{fit}{infer}(object, mode = "regression", ...)
+\method{fit}{infer}(object, ...)
 }
 \arguments{
 \item{object}{Output from an infer function---likely \code{\link[=generate]{generate()}} or
 \code{\link[=specify]{specify()}}---which specifies the formula and data to fit a model to.}
-
-\item{mode}{One of "regression" or "classification"---the model type,
-determined by the outcome variable. If a \code{family} argument is passed
-via \code{...}, this argument will be ignored.}
 
 \item{...}{Any optional arguments to pass along to the model fitting
 function. See \code{\link[stats:glm]{stats::glm()}} for more information.}
@@ -90,10 +86,11 @@ null_fits <- gss \%>\%
 
 null_fits
 
-# for logistic regression, set `mode = "classification"`
+# for logistic regression, just supply a binary response variable!
+# (this can also be made explicit via the `family` argument in ...)
 gss \%>\%
   specify(college ~ age + hours) \%>\%
-  fit(mode = "classification")
+  fit()
 
 # more in-depth explanation of how to use the infer package
 \dontrun{

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -90,6 +90,11 @@ null_fits <- gss \%>\%
 
 null_fits
 
+# for logistic regression, set `mode = "classification"`
+gss \%>\%
+  specify(college ~ age + hours) \%>\%
+  fit(mode = "classification")
+
 # more in-depth explanation of how to use the infer package
 \dontrun{
 vignette("infer")

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -32,11 +32,11 @@ earlier in the pipeline. If passed the output of \code{\link[=specify]{specify()
 \code{\link[=hypothesize]{hypothesize()}}, the function will fit one model. If passed the output
 of \code{\link[=generate]{generate()}}, it will fit a model to each data resample, denoted in
 the \code{replicate} column. The family of the fitted model depends on the type
-of the response variable. If the response is numeric, \code{fit()} will default
-to \code{family = "gaussian"}. If the response is a 2-level character or
-factor, \code{fit()} will default to \code{family = "gaussian"}. To fit character or
-factor response variables with more than two levels, we recommend
-\code{\link[parsnip:multinom_reg]{parsnip::multinom_reg()}}.
+of the response variable. If the response is numeric, \code{fit()} will use
+\code{family = "gaussian"} (linear regression). If the response is a 2-level
+factor or character, \code{fit()} will use \code{family = "binomial"} (logistic
+regression). To fit character or factor response variables with more than
+two levels, we recommend \code{\link[parsnip:multinom_reg]{parsnip::multinom_reg()}}.
 
 infer provides a fit "method" for infer objects, which is a way of carrying
 out model fitting as applied to infer output. The "generic," imported from

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -107,7 +107,7 @@ test_that("fit.infer logistic regression works", {
   expect_error(
     gss %>%
       specify(finrela ~ age + college) %>%
-      fit(mode = "classification"),
+      fit(),
     "infer does not support.*more than two levels"
   )
   

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -82,57 +82,25 @@ test_that("fit.infer messages informatively on excessive null", {
   )
 })
 
-test_that("fit.infer `mode` and logistic regression work", {
-  # defaults to regression (correct usage)
+test_that("fit.infer logistic regression works", {
+  # linear regression default works
   expect_equal(
     gss %>%
       specify(hours ~ age + college) %>%
       fit(),
     gss %>%
       specify(hours ~ age + college) %>%
-      fit(mode = "regression")
+      fit(family = stats::gaussian)
   )
   
-  # correct usage for classification
-  expect_silent(
-    gss %>%
-      specify(college ~ age + hours) %>%
-      fit(mode = "classification")
-  )
-  
-  # needs mode for classification
-  expect_error(
-    gss %>%
-      specify(college ~ age + hours) %>%
-      fit(),
-    '`mode = "classification"`.*dichotomous categorical response'
-  )
-  
-  # bad mode
-  expect_error(
-    gss %>%
-      specify(college ~ age + hours) %>%
-      fit(mode = "boop"),
-    '`mode` argument must be one of "regression" or "classification".'
-  )
-  
-  # override mode via family
+  # logistic regression default works
   expect_equal(
     gss %>%
       specify(college ~ age + hours) %>%
       fit(family = stats::binomial),
     gss %>%
       specify(college ~ age + hours) %>%
-      fit(mode = "classification")
-  )
-  
-  expect_equal(
-    gss %>%
-      specify(hours ~ age + college) %>%
-      fit(family = stats::gaussian),
-    gss %>%
-      specify(hours ~ age + college) %>%
-      fit(mode = "regression")
+      fit()
   )
   
   # errors informatively with multinomial response variable
@@ -148,11 +116,11 @@ test_that("fit.infer `mode` and logistic regression work", {
     specify(college ~ age + hours) %>%
     hypothesize(null = "independence") %>%
     generate(type = "permute", reps = 2) %>%
-    fit(mode = "classification")
+    fit()
   
   fit_obs <- gss %>%
     specify(college ~ age + hours) %>%
-    fit(mode = "classification")
+    fit()
 
   expect_equal(nrow(fit_gen), nrow(fit_obs) * 2)
   expect_equal(ncol(fit_gen), ncol(fit_obs) + 1)
@@ -160,11 +128,11 @@ test_that("fit.infer `mode` and logistic regression work", {
   # responds to success argument
   fit_deg <- gss %>%
     specify(college ~ age + hours, success = "degree") %>%
-    fit(mode = "classification")
+    fit()
   
   fit_no_deg <- gss %>%
     specify(college ~ age + hours, success = "no degree") %>%
-    fit(mode = "classification")
+    fit()
 
   expect_equal(fit_deg$term, fit_no_deg$term)
   expect_equal(fit_deg$estimate, -fit_no_deg$estimate)


### PR DESCRIPTION
This PR introduces (explicit) support for logistic regression in `fit.infer` via the `mode` argument! Previously, we had supported logistic regression already if a `family` argument was passed via `...`, but this implements a more tidymodels-esque and well-documented interface.

A quick reprex of the interface:

``` r
library(infer)

# mode argument defaults to regression
gss %>%
  specify(hours ~ age + college) %>%
  fit()
#> # A tibble: 3 x 2
#>   term          estimate
#>   <chr>            <dbl>
#> 1 intercept     40.6    
#> 2 age            0.00596
#> 3 collegedegree  1.53

# supply `mode = "classification"` for logistic regression
gss %>%
  specify(college ~ age + hours) %>%
  fit(mode = "classification")
#> # A tibble: 3 x 2
#>   term      estimate
#>   <chr>        <dbl>
#> 1 intercept -1.13   
#> 2 age        0.00527
#> 3 hours      0.00698
```

On the backend, `mode` just handles the `family` argument to `stats::glm`. Supplying the `family` argument via `...` means the `mode` argument will be ignored.

``` r
testthat::expect_equal(
  gss %>%
    specify(college ~ age + hours) %>%
    fit(family = stats::binomial),
  gss %>%
    specify(college ~ age + hours) %>%
    fit(mode = "classification")
)

testthat::expect_equal(
  gss %>%
    specify(hours ~ age + college) %>%
    fit(family = stats::gaussian),
  gss %>%
    specify(hours ~ age + college) %>%
    fit(mode = "regression")
)
```

`stats::glm` doesn’t support multinomial classification (as far as I understand), so we defer to `parsnip` here:

``` r
gss %>%
  specify(finrela ~ age + college) %>%
  fit(mode = "classification")
#> Error: infer does not support fitting models on categorical response variables with more than 
#> two levels. Please see `multinom_reg()` from the parsnip package.
```

The functionality is unit tested for handling `generate()`d objects and sensitivity to the `success` argument to `specify()`.

<sup>Created on 2021-06-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>