### PR TITLE
rename `generate()`s `cols` argument to `variables`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -172,13 +172,13 @@ gss %>%
 #> # … with 290 more rows
 ```
 
-If `type = "permute"`, a set of unquoted column names in the data to permute (independently of each other) can be passed via the `cols` argument to `generate`. It defaults to only the response variable.
+If `type = "permute"`, a set of unquoted column names in the data to permute (independently of each other) can be passed via the `variables` argument to `generate`. It defaults to only the response variable.
 
 ``` r
 gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
-  generate(reps = 100, type = "permute", cols = c(age, college)) %>%
+  generate(reps = 100, type = "permute", variables = c(age, college)) %>%
   fit()
 #> # A tibble: 300 x 3
 #> # Groups:   replicate [100]

--- a/R/fit.R
+++ b/R/fit.R
@@ -57,7 +57,7 @@ generics::fit
 #' beyond those required for one explanatory variable. Namely, the distribution
 #' of the response variable must be similar to the distribution of the errors
 #' under the null hypothesis' specification of a fixed effect of the explanatory 
-#' variables. (This null hypothesis is reflected in the `cols` argument to 
+#' variables. (This null hypothesis is reflected in the `variables` argument to 
 #' [generate()]. By default, all of the explanatory variables are treated
 #' as fixed.) A general rule of thumb here is, if there are large outliers
 #' in the distributions of any of the explanatory variables, this distributional

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -56,7 +56,7 @@ elsewhere in the package, is subject to additional distributional assumptions
 beyond those required for one explanatory variable. Namely, the distribution
 of the response variable must be similar to the distribution of the errors
 under the null hypothesis' specification of a fixed effect of the explanatory
-variables. (This null hypothesis is reflected in the \code{cols} argument to
+variables. (This null hypothesis is reflected in the \code{variables} argument to
 \code{\link[=generate]{generate()}}. By default, all of the explanatory variables are treated
 as fixed.) A general rule of thumb here is, if there are large outliers
 in the distributions of any of the explanatory variables, this distributional

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -4,7 +4,7 @@
 \alias{generate}
 \title{Generate resamples, permutations, or simulations}
 \usage{
-generate(x, reps = 1, type = NULL, cols = !!response_expr(x), ...)
+generate(x, reps = 1, type = NULL, variables = !!response_expr(x), ...)
 }
 \arguments{
 \item{x}{A data frame that can be coerced into a \link[tibble:tibble]{tibble}.}
@@ -15,7 +15,7 @@ generate(x, reps = 1, type = NULL, cols = !!response_expr(x), ...)
 data reflecting the null hypothesis. Currently one of
 \code{"bootstrap"}, \code{"permute"}, or \code{"draw"} (see below).}
 
-\item{cols}{If \code{type = "permute"}, a set of unquoted column names in the
+\item{variables}{If \code{type = "permute"}, a set of unquoted column names in the
 data to permute (independently of each other). Defaults to only the
 response variable.}
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -323,7 +323,7 @@ test_that("generate() can permute with multiple explanatory variables", {
   expect_equal(ncol(x), 4)
 })
 
-test_that("generate is sensitive to the cols argument", {
+test_that("generate is sensitive to the variables argument", {
   # default argument works appropriately
   expect_equal({ 
       set.seed(1)
@@ -338,7 +338,7 @@ test_that("generate is sensitive to the cols argument", {
       gss[1:10,] %>%
         specify(hours ~ age + college) %>%
         hypothesize(null = "independence") %>%
-        generate(reps = 2, type = "permute", cols = hours)
+        generate(reps = 2, type = "permute", variables = hours)
   })
   
   # permuting changes output
@@ -346,7 +346,7 @@ test_that("generate is sensitive to the cols argument", {
     perm_age <- gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = age)
+      generate(reps = 2, type = "permute", variables = age)
   )
   
   expect_false(all(perm_age$age[1:10] == perm_age$age[11:20]))
@@ -357,7 +357,7 @@ test_that("generate is sensitive to the cols argument", {
     perm_college <- gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = college)
+      generate(reps = 2, type = "permute", variables = college)
   )
   
   expect_true(all(perm_college$age[1:10] == perm_college$age[11:20]))
@@ -368,7 +368,7 @@ test_that("generate is sensitive to the cols argument", {
     perm_college_age <- gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = c(college, age))
+      generate(reps = 2, type = "permute", variables = c(college, age))
   )
   
   expect_false(all(perm_college_age$age[1:10] == perm_college_age$age[11:20]))
@@ -376,12 +376,12 @@ test_that("generate is sensitive to the cols argument", {
   expect_false(all(perm_college_age$college[1:10] == perm_college_age$college[11:20]))
 })
 
-test_that("cols argument prompts when it ought to", {
+test_that("variables argument prompts when it ought to", {
   expect_error(
     gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = c(howdy)),
+      generate(reps = 2, type = "permute", variables = c(howdy)),
     "column `howdy`.*is not in the supplied data."
   )
   
@@ -389,7 +389,7 @@ test_that("cols argument prompts when it ought to", {
     gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = c(howdy, doo)),
+      generate(reps = 2, type = "permute", variables = c(howdy, doo)),
     'columns `c\\("howdy", "doo"\\)`.*are not in the supplied data.'
   )
   
@@ -397,7 +397,7 @@ test_that("cols argument prompts when it ought to", {
     gss[1:10,] %>%
       specify(hours ~ NULL) %>%
       hypothesize(null = "point", mu = 40) %>%
-      generate(reps = 2, type = "bootstrap", cols = c(hours)),
+      generate(reps = 2, type = "bootstrap", variables = c(hours)),
     "is only relevant for.*will be ignored."
   )
   
@@ -405,7 +405,7 @@ test_that("cols argument prompts when it ought to", {
     gss[1:10,] %>%
       specify(hours ~ age + college) %>%
       hypothesize(null = "independence") %>%
-      generate(reps = 2, type = "permute", cols = "hours"),
+      generate(reps = 2, type = "permute", variables = "hours"),
     'unquoted variable names'
   )
 })

--- a/vignettes/infer.Rmd
+++ b/vignettes/infer.Rmd
@@ -288,7 +288,7 @@ null_fits <- gss %>%
 null_fits
 ```
 
-To permute variables other than the response variable, the `cols` argument to `generate()` allows you to choose any of the `specify()`ed variables to permute independently of each other.
+To permute variables other than the response variable, the `variables` argument to `generate()` allows you to choose any of the `specify()`ed variables to permute independently of each other.
 
 Beyond this point, observed fits and distributions from null fits interface exactly like analogous outputs from `calculate()`. For instance, we can use the following code to calculate a 95% confidence interval from these objects.
 

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -1008,7 +1008,7 @@ Generating a distribution of fits where each explanatory variable is permuted in
 null_distn2 <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
-  generate(reps = 1000, type = "permute", cols = c(age, college)) %>%
+  generate(reps = 1000, type = "permute", variables = c(age, college)) %>%
   fit()
 ```
 
@@ -1516,7 +1516,7 @@ Alternatively, generating a distribution of fits where each explanatory variable
 null_distn2 <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
-  generate(reps = 1000, type = "permute", cols = c(age, college)) %>%
+  generate(reps = 1000, type = "permute", variables = c(age, college)) %>%
   fit()
 ```
 


### PR DESCRIPTION
re: the tidyverse team's feedback, rename `generate()`s `cols` argument to `variables` so as not to obfuscate columns in the data frame and terms in the model. Since `terms` is currently only used to refer to explanatory variables elsewhere in the package, we use `variables`. :-)