### PR TITLE
standardize distribution naming

### DIFF
--- a/R/get_confidence_interval.R
+++ b/R/get_confidence_interval.R
@@ -64,7 +64,7 @@
 #'
 #' @examples
 #'
-#' boot_distr <- gss %>%
+#' boot_dist <- gss %>%
 #'   # We're interested in the number of hours worked per week
 #'   specify(response = hours) %>%
 #'   # Generate bootstrap samples
@@ -72,7 +72,7 @@
 #'   # Calculate mean of each bootstrap sample
 #'   calculate(stat = "mean")
 #'
-#' boot_distr %>%
+#' boot_dist %>%
 #'   # Calculate the confidence interval around the point estimate
 #'   get_confidence_interval(
 #'     # At the 95% confidence level; percentile method
@@ -84,7 +84,7 @@
 #'   specify(response = hours) %>%
 #'   calculate(stat = "mean")
 #'
-#' boot_distr %>%
+#' boot_dist %>%
 #'   get_confidence_interval(
 #'     point_estimate = sample_mean,
 #'     # At the 95% confidence level

--- a/R/shade_p_value.R
+++ b/R/shade_p_value.R
@@ -55,11 +55,11 @@
 #'   
 #' # you can shade confidence intervals on top of
 #' # theoretical distributions, too!
-#' null_dist_theor <- gss %>%
+#' null_dist_theory <- gss %>%
 #'   specify(response = hours) %>%
 #'   assume(distribution = "t") 
 #'   
-#' null_dist_theor %>%
+#' null_dist_theory %>%
 #'   visualize() +
 #'   shade_p_value(obs_stat = point_estimate, direction = "two-sided")
 #' 

--- a/R/shade_p_value.R
+++ b/R/shade_p_value.R
@@ -55,11 +55,11 @@
 #'   
 #' # you can shade confidence intervals on top of
 #' # theoretical distributions, too!
-#' null_dist_theoretical <- gss %>%
+#' null_dist_theor <- gss %>%
 #'   specify(response = hours) %>%
 #'   assume(distribution = "t") 
 #'   
-#' null_dist_theoretical %>%
+#' null_dist_theor %>%
 #'   visualize() +
 #'   shade_p_value(obs_stat = point_estimate, direction = "two-sided")
 #' 

--- a/README.Rmd
+++ b/README.Rmd
@@ -86,7 +86,7 @@ F_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r, message = FALSE, warning = FALSE}
-null_distn <- gss %>%
+null_dist <- gss %>%
    specify(age ~ partyid) %>%
    hypothesize(null = "independence") %>%
    generate(reps = 1000, type = "permute") %>%
@@ -96,7 +96,7 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r viz, message = FALSE, warning = FALSE, eval = FALSE}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
@@ -107,7 +107,7 @@ knitr::include_graphics("https://raw.githubusercontent.com/tidymodels/infer/mast
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r, message = FALSE, warning = FALSE}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = F_hat, direction = "greater")
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ F_hat <- gss %>%
 Then, generating the null distribution,
 
 ``` r
-null_distn <- gss %>%
+null_dist <- gss %>%
    specify(age ~ partyid) %>%
    hypothesize(null = "independence") %>%
    generate(reps = 1000, type = "permute") %>%
@@ -139,7 +139,7 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ``` r
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
@@ -155,7 +155,7 @@ Calculating the p-value from the null distribution and observed
 statistic,
 
 ``` r
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = F_hat, direction = "greater")
 ```
 

--- a/man/get_confidence_interval.Rd
+++ b/man/get_confidence_interval.Rd
@@ -79,7 +79,7 @@ point estimates:
 
 \examples{
 
-boot_distr <- gss \%>\%
+boot_dist <- gss \%>\%
   # We're interested in the number of hours worked per week
   specify(response = hours) \%>\%
   # Generate bootstrap samples
@@ -87,7 +87,7 @@ boot_distr <- gss \%>\%
   # Calculate mean of each bootstrap sample
   calculate(stat = "mean")
 
-boot_distr \%>\%
+boot_dist \%>\%
   # Calculate the confidence interval around the point estimate
   get_confidence_interval(
     # At the 95\% confidence level; percentile method
@@ -99,7 +99,7 @@ sample_mean <- gss \%>\%
   specify(response = hours) \%>\%
   calculate(stat = "mean")
 
-boot_distr \%>\%
+boot_dist \%>\%
   get_confidence_interval(
     point_estimate = sample_mean,
     # At the 95\% confidence level

--- a/man/shade_p_value.Rd
+++ b/man/shade_p_value.Rd
@@ -68,11 +68,11 @@ null_dist \%>\%
   
 # you can shade confidence intervals on top of
 # theoretical distributions, too!
-null_dist_theor <- gss \%>\%
+null_dist_theory <- gss \%>\%
   specify(response = hours) \%>\%
   assume(distribution = "t") 
   
-null_dist_theor \%>\%
+null_dist_theory \%>\%
   visualize() +
   shade_p_value(obs_stat = point_estimate, direction = "two-sided")
 

--- a/man/shade_p_value.Rd
+++ b/man/shade_p_value.Rd
@@ -68,11 +68,11 @@ null_dist \%>\%
   
 # you can shade confidence intervals on top of
 # theoretical distributions, too!
-null_dist_theoretical <- gss \%>\%
+null_dist_theor <- gss \%>\%
   specify(response = hours) \%>\%
   assume(distribution = "t") 
   
-null_dist_theoretical \%>\%
+null_dist_theor \%>\%
   visualize() +
   shade_p_value(obs_stat = point_estimate, direction = "two-sided")
 

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -255,7 +255,7 @@ test_that("theoretical CIs align with simulation-based (mean)", {
     generate(reps = 1e3, type = "bootstrap") %>% 
     calculate(stat = "mean")
   
-  null_dist_theor <- gss %>%
+  null_dist_theory <- gss %>%
     specify(response = hours) %>%
     hypothesize(null = "point", mu = 40) %>%
     assume(distribution = "t")
@@ -268,7 +268,7 @@ test_that("theoretical CIs align with simulation-based (mean)", {
       point_estimate = x_bar
     ),
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       .95, 
       type = "se", 
       point_estimate = x_bar
@@ -290,7 +290,7 @@ test_that("theoretical CIs align with simulation-based (prop)", {
     generate(reps = 1e3, type = "draw") %>%
     calculate(stat = "prop")
   
-  null_dist_theor <- gss %>%
+  null_dist_theory <- gss %>%
     specify(response = sex, success = "female") %>%
     assume(distribution = "z")
   
@@ -302,7 +302,7 @@ test_that("theoretical CIs align with simulation-based (prop)", {
       point_estimate = p_hat
     ),
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       .95, 
       type = "se", 
       point_estimate = p_hat
@@ -324,7 +324,7 @@ test_that("theoretical CIs align with simulation-based (diff in means)", {
     generate(reps = 3e3, type = "permute") %>% 
     calculate(stat = "diff in means", order = c("degree", "no degree"))
   
-  null_dist_theor <- gss %>%
+  null_dist_theory <- gss %>%
     specify(age ~ college) %>% 
     assume(distribution = "t")
   
@@ -336,7 +336,7 @@ test_that("theoretical CIs align with simulation-based (diff in means)", {
       point_estimate = diff_bar
     ),
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       .95, 
       type = "se", 
       point_estimate = diff_bar
@@ -358,7 +358,7 @@ test_that("theoretical CIs align with simulation-based (diff in props)", {
     generate(reps = 1e3, type = "permute") %>%
     calculate(stat = "diff in props", order = c("female", "male"))
   
-  null_dist_theor <- gss %>%
+  null_dist_theory <- gss %>%
     specify(college ~ sex, success = "no degree") %>%
     assume(distribution = "z")
   
@@ -370,7 +370,7 @@ test_that("theoretical CIs align with simulation-based (diff in props)", {
       point_estimate = diff_hat
     ),
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       .95, 
       type = "se", 
       point_estimate = diff_hat
@@ -384,19 +384,19 @@ test_that("theoretical CIs check arguments properly", {
     specify(response = hours) %>%
     calculate(stat = "mean")
   
-  null_dist_theor <- gss %>%
+  null_dist_theory <- gss %>%
     specify(age ~ college) %>% 
     assume(distribution = "t")
   
   # check that type is handled correctly
   expect_equal(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95, 
       point_estimate = x_bar
     ),
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95,
       type = "se",
       point_estimate = x_bar
@@ -405,7 +405,7 @@ test_that("theoretical CIs check arguments properly", {
   
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95,
       type = "percentile",
       point_estimate = x_bar
@@ -415,7 +415,7 @@ test_that("theoretical CIs check arguments properly", {
   
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95,
       type = "boop",
       point_estimate = x_bar
@@ -426,7 +426,7 @@ test_that("theoretical CIs check arguments properly", {
   # check that point estimate hasn't been post-processed
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95, 
       point_estimate = dplyr::pull(x_bar)
     ),
@@ -435,7 +435,7 @@ test_that("theoretical CIs check arguments properly", {
   
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95, 
       point_estimate = x_bar$stat
     ),
@@ -450,7 +450,7 @@ test_that("theoretical CIs check arguments properly", {
   
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95, 
       point_estimate = obs_t
     ),
@@ -468,7 +468,7 @@ test_that("theoretical CIs check arguments properly", {
   
   expect_error(
     get_confidence_interval(
-      null_dist_theor, 
+      null_dist_theory, 
       level = .95, 
       point_estimate = p_hat
     ),

--- a/vignettes/anova.Rmd
+++ b/vignettes/anova.Rmd
@@ -61,7 +61,7 @@ We can `generate` an approximation of the null distribution using randomization.
 
 ```{r generate-null-f, warning = FALSE, message = FALSE}
 # generate the null distribution using randomization
-null_distribution <- gss %>%
+null_dist <- gss %>%
   specify(age ~ partyid) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -74,7 +74,7 @@ To get a sense for what this distribution looks like, and where our observed sta
 
 ```{r visualize-f, warning = FALSE, message = FALSE}
 # visualize the null distribution and test statistic!
-null_distribution %>%
+null_dist %>%
   visualize() + 
   shade_p_value(observed_f_statistic,
                 direction = "greater")
@@ -84,11 +84,11 @@ We could also visualize the observed statistic against the theoretical null dist
 
 ```{r visualize-f-theor, warning = FALSE, message = FALSE}
 # visualize the theoretical null distribution and test statistic!
-null_dist_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(age ~ partyid) %>%
   assume(distribution = "F")
 
-visualize(null_dist_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(observed_f_statistic,
                 direction = "greater")
 ```
@@ -97,7 +97,7 @@ To visualize both the randomization-based and theoretical null distributions to 
 
 ```{r visualize-indep-both, warning = FALSE, message = FALSE}
 # visualize both null distributions and the test statistic!
-null_distribution %>%
+null_dist %>%
   visualize(method = "both") + 
   shade_p_value(observed_f_statistic,
                 direction = "greater")
@@ -107,7 +107,7 @@ Either way, it looks like our observed test statistic would be quite unlikely if
 
 ```{r p-value-indep, warning = FALSE, message = FALSE}
 # calculate the p value from the observed statistic and null distribution
-p_value <- null_distribution %>%
+p_value <- null_dist %>%
   get_p_value(obs_stat = observed_f_statistic,
               direction = "greater")
 

--- a/vignettes/anova.Rmd
+++ b/vignettes/anova.Rmd
@@ -84,11 +84,11 @@ We could also visualize the observed statistic against the theoretical null dist
 
 ```{r visualize-f-theor, warning = FALSE, message = FALSE}
 # visualize the theoretical null distribution and test statistic!
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(age ~ partyid) %>%
   assume(distribution = "F")
 
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(observed_f_statistic,
                 direction = "greater")
 ```

--- a/vignettes/chi_squared.Rmd
+++ b/vignettes/chi_squared.Rmd
@@ -65,7 +65,7 @@ We can `generate` the null distribution in one of two ways---using randomization
 
 ```{r generate-null-indep, warning = FALSE, message = FALSE}
 # generate the null distribution using randomization
-null_distribution_simulated <- gss %>%
+null_dist_sim <- gss %>%
   specify(college ~ finrela) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -76,7 +76,7 @@ Note that, in the line `specify(college ~ finrela)` above, we could use the equi
 
 ```{r generate-null-indep-t, warning = FALSE, message = FALSE}
 # generate the null distribution by theoretical approximation
-null_distribution_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(college ~ finrela) %>%
   assume(distribution = "Chisq")
 ```
@@ -85,7 +85,7 @@ To get a sense for what these distributions look like, and where our observed st
 
 ```{r visualize-indep, warning = FALSE, message = FALSE}
 # visualize the null distribution and test statistic!
-null_distribution_simulated %>%
+null_dist_sim %>%
   visualize() + 
   shade_p_value(observed_indep_statistic,
                 direction = "greater")
@@ -107,7 +107,7 @@ To visualize both the randomization-based and theoretical null distributions to 
 
 ```{r visualize-indep-both, warning = FALSE, message = FALSE}
 # visualize both null distributions and the test statistic!
-null_distribution_simulated %>%
+null_dist_sim %>%
   visualize(method = "both") + 
   shade_p_value(observed_indep_statistic,
                 direction = "greater")
@@ -117,7 +117,7 @@ Either way, it looks like our observed test statistic would be quite unlikely if
 
 ```{r p-value-indep, warning = FALSE, message = FALSE}
 # calculate the p value from the observed statistic and null distribution
-p_value_independence <- null_distribution_simulated %>%
+p_value_independence <- null_dist_sim %>%
   get_p_value(obs_stat = observed_indep_statistic,
               direction = "greater")
 
@@ -176,7 +176,7 @@ The observed statistic is `r observed_gof_statistic`. Now, generating a null dis
 
 ```{r null-distribution-gof, warning = FALSE, message = FALSE}
 # generating a null distribution, assuming each income class is equally likely
-null_distribution_gof <- gss %>%
+null_dist_gof <- gss %>%
   specify(response = finrela) %>%
   hypothesize(null = "point",
               p = c("far below average" = 1/6,
@@ -193,7 +193,7 @@ Again, to get a sense for what these distributions look like, and where our obse
 
 ```{r visualize-indep-gof, warning = FALSE, message = FALSE}
 # visualize the null distribution and test statistic!
-null_distribution_gof %>%
+null_dist_gof %>%
   visualize() + 
   shade_p_value(observed_gof_statistic,
                 direction = "greater")
@@ -203,7 +203,7 @@ This statistic seems like it would be quite unlikely if income class self-identi
 
 ```{r get-p-value-gof, warning = FALSE, message = FALSE}
 # calculate the p-value
-p_value_gof <- null_distribution_gof %>%
+p_value_gof <- null_dist_gof %>%
   get_p_value(observed_gof_statistic,
               direction = "greater")
 

--- a/vignettes/chi_squared.Rmd
+++ b/vignettes/chi_squared.Rmd
@@ -76,7 +76,7 @@ Note that, in the line `specify(college ~ finrela)` above, we could use the equi
 
 ```{r generate-null-indep-t, warning = FALSE, message = FALSE}
 # generate the null distribution by theoretical approximation
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(college ~ finrela) %>%
   assume(distribution = "Chisq")
 ```

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -28,7 +28,6 @@ library(dplyr)
 devtools::load_all()
 ```
 
-
 ```{r load-gss}
 # load in the dataset
 data(gss)
@@ -59,7 +58,7 @@ x_bar <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = hours) %>%
   hypothesize(null = "point", mu = 40) %>%
   generate(reps = 1000) %>%
@@ -69,14 +68,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = x_bar, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = x_bar, direction = "two-sided")
 ```
 
@@ -101,7 +100,7 @@ t_bar <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = hours) %>%
   hypothesize(null = "point", mu = 40) %>%
   generate(reps = 1000) %>%
@@ -111,7 +110,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(response = hours)  %>%
   assume("t")
 ```
@@ -119,21 +118,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = t_bar, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = t_bar, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn, method = "both") +
+visualize(null_dist, method = "both") +
   shade_p_value(obs_stat = t_bar, direction = "two-sided")
 ```
 
@@ -142,7 +141,7 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = t_bar, direction = "two-sided")
 ```
 
@@ -175,7 +174,7 @@ x_tilde <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = age) %>%
   hypothesize(null = "point", med = 40) %>% 
   generate(reps = 1000) %>% 
@@ -185,14 +184,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = x_tilde, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = x_tilde, direction = "two-sided")
 ```
 
@@ -216,7 +215,7 @@ p_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = sex, success = "female") %>%
   hypothesize(null = "point", p = .5) %>%
   generate(reps = 1000) %>%
@@ -226,21 +225,21 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = p_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = p_hat, direction = "two-sided")
 ```
 
 Note that logical variables will be coerced to factors:
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   dplyr::mutate(is_female = (sex == "female")) %>%
   specify(response = is_female, success = "TRUE") %>%
   hypothesize(null = "point", p = .5) %>%
@@ -269,7 +268,7 @@ p_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = sex, success = "female") %>%
   hypothesize(null = "point", p = .5) %>%
   generate(reps = 1000, type = "draw") %>%
@@ -279,14 +278,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = p_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = p_hat, direction = "two-sided")
 ```
 
@@ -302,7 +301,7 @@ prop_test(gss,
 
 ### Two categorical (2 level) variables
 
-The `infer` package provides several statistics to work with data of this type. One of them is the statistic for difference in proportions. 
+The `infer` package provides several statistics to work with data of this type. One of them is the statistic for difference in proportions.
 
 Calculating the observed statistic,
 
@@ -323,7 +322,7 @@ d_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   hypothesize(null = "independence") %>% 
   generate(reps = 1000) %>% 
@@ -333,14 +332,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
@@ -365,7 +364,7 @@ r_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   hypothesize(null = "independence") %>% 
   generate(reps = 1000) %>% 
@@ -375,14 +374,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = r_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = r_hat, direction = "two-sided")
 ```
 
@@ -399,7 +398,7 @@ or_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   hypothesize(null = "independence") %>% 
   generate(reps = 1000) %>% 
@@ -409,14 +408,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = or_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = or_hat, direction = "two-sided")
 ```
 
@@ -442,7 +441,7 @@ z_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   hypothesize(null = "independence") %>% 
   generate(reps = 1000) %>% 
@@ -452,7 +451,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   assume("z")
 ```
@@ -460,21 +459,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = z_hat, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = z_hat, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn, method = "both") +
+visualize(null_dist, method = "both") +
   shade_p_value(obs_stat = z_hat, direction = "two-sided")
 ```
 
@@ -483,7 +482,7 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = z_hat, direction = "two-sided")
 ```
 
@@ -497,7 +496,7 @@ prop_test(gss,
           order = c("female", "male"))
 ```
 
-### One categorical (>2 level) - GoF
+### One categorical (\>2 level) - GoF
 
 Calculating the observed statistic,
 
@@ -534,7 +533,7 @@ Chisq_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(response = finrela) %>%
   hypothesize(null = "point",
               p = c("far below average" = 1/6,
@@ -550,7 +549,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(response = finrela) %>%
   assume("Chisq")
 ```
@@ -558,21 +557,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn_theoretical, method = "both") +
+visualize(null_dist_theor, method = "both") +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -581,7 +580,7 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -598,7 +597,7 @@ chisq_test(gss,
                  "DK" = 1/6))
 ```
 
-### Two categorical (>2 level): Chi-squared test of independence
+### Two categorical (\>2 level): Chi-squared test of independence
 
 Calculating the observed statistic,
 
@@ -619,7 +618,7 @@ Chisq_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(finrela ~ sex) %>%
   hypothesize(null = "independence") %>% 
   generate(reps = 1000, type = "permute") %>% 
@@ -629,7 +628,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(finrela ~ sex) %>%
   assume(distribution = "Chisq")
 ```
@@ -637,21 +636,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn, method = "both") +
+visualize(null_dist, method = "both") +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -660,7 +659,7 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -692,7 +691,7 @@ d_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(age ~ college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -702,14 +701,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
@@ -735,7 +734,7 @@ t_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(age ~ college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -745,7 +744,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
   specify(age ~ college) %>%
   assume("t")
 ```
@@ -753,21 +752,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = t_hat, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = t_hat, direction = "two-sided")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn, method = "both") +
+visualize(null_dist, method = "both") +
   shade_p_value(obs_stat = t_hat, direction = "two-sided")
 ```
 
@@ -776,7 +775,7 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = t_hat, direction = "two-sided")
 ```
 
@@ -803,7 +802,7 @@ d_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(age ~ college) %>% # alt: response = age, explanatory = season
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -813,18 +812,18 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = d_hat, direction = "two-sided")
 ```
 
-### One numerical, one categorical (>2 levels) -  ANOVA
+### One numerical, one categorical (\>2 levels) - ANOVA
 
 Calculating the observed statistic,
 
@@ -844,7 +843,7 @@ F_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
    specify(age ~ partyid) %>%
    hypothesize(null = "independence") %>%
    generate(reps = 1000, type = "permute") %>%
@@ -854,7 +853,7 @@ null_distn <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_distn_theoretical <- gss %>%
+null_dist_theor <- gss %>%
    specify(age ~ partyid) %>%
    hypothesize(null = "independence") %>%
    assume(distribution = "F")
@@ -863,21 +862,21 @@ null_distn_theoretical <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_distn_theoretical) +
+visualize(null_dist_theor) +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_distn, mdthod = "both") +
+visualize(null_dist, method = "both") +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
@@ -886,11 +885,11 @@ Note that the above code makes use of the randomization-based null distribution.
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = F_hat, direction = "greater")
 ```
 
-### Two numerical vars - SLR 
+### Two numerical vars - SLR
 
 Calculating the observed statistic,
 
@@ -910,7 +909,7 @@ slope_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
    specify(hours ~ age) %>% 
    hypothesize(null = "independence") %>%
    generate(reps = 1000, type = "permute") %>%
@@ -920,14 +919,14 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = slope_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = slope_hat, direction = "two-sided")
 ```
 
@@ -951,7 +950,7 @@ correlation_hat <- gss %>%
 Then, generating the null distribution,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
    specify(hours ~ age) %>% 
    hypothesize(null = "independence") %>%
    generate(reps = 1000, type = "permute") %>%
@@ -961,17 +960,16 @@ null_distn <- gss %>%
 Visualizing the observed statistic alongside the null distribution,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = correlation_hat, direction = "two-sided")
 ```
 
 Calculating the p-value from the null distribution and observed statistic,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = correlation_hat, direction = "two-sided")
 ```
-
 
 ### Two numerical vars - SLR (t)
 
@@ -990,7 +988,7 @@ obs_fit <- gss %>%
 Generating a distribution of fits with the response variable permuted,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -1000,7 +998,7 @@ null_distn <- gss %>%
 Generating a distribution of fits where each explanatory variable is permuted independently,
 
 ```{r}
-null_distn2 <- gss %>%
+null_dist2 <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute", variables = c(age, college)) %>%
@@ -1010,14 +1008,14 @@ null_distn2 <- gss %>%
 Visualizing the observed fit alongside the null fits,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_p_value(obs_stat = obs_fit, direction = "two-sided")
 ```
 
 Calculating p-values from the null distribution and observed fit,
 
 ```{r}
-null_distn %>%
+null_dist %>%
   get_p_value(obs_stat = obs_fit, direction = "two-sided")
 ```
 
@@ -1045,7 +1043,7 @@ x_bar <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(response = hours) %>%
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "mean")
@@ -1054,13 +1052,13 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
@@ -1069,7 +1067,7 @@ Alternatively, use the bootstrap distribution to find a confidence interval usin
 ```{r}
 standard_error_ci <- get_ci(boot, type = "se", point_estimate = x_bar)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1117,7 +1115,7 @@ t_hat <- gss %>%
 Then, generating the bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(response = hours) %>%
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "t")
@@ -1126,23 +1124,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = t_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1168,7 +1166,7 @@ p_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
  specify(response = sex, success = "female") %>%
  generate(reps = 1000, type = "bootstrap") %>%
  calculate(stat = "prop")
@@ -1177,23 +1175,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = p_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1243,7 +1241,7 @@ d_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(hours ~ college) %>%
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "diff in means", order = c("degree", "no degree"))
@@ -1252,23 +1250,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = d_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1314,7 +1312,7 @@ t_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(hours ~ college) %>%
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "t", order = c("degree", "no degree"))
@@ -1323,23 +1321,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = t_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1366,7 +1364,7 @@ d_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
   specify(college ~ sex, success = "degree") %>%
   generate(reps = 1000, type = "bootstrap") %>% 
   calculate(stat = "diff in props", order = c("female", "male"))
@@ -1375,23 +1373,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = d_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1437,7 +1435,7 @@ z_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
   specify(college ~ sex, success = "degree") %>%
   generate(reps = 1000, type = "bootstrap") %>% 
   calculate(stat = "z", order = c("female", "male"))
@@ -1446,23 +1444,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = z_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1488,7 +1486,7 @@ slope_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(hours ~ age) %>% 
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "slope")
@@ -1497,23 +1495,23 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = slope_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
 
@@ -1537,7 +1535,7 @@ correlation_hat <- gss %>%
 Then, generating a bootstrap distribution,
 
 ```{r}
-boot <- gss %>%
+boot_dist <- gss %>%
    specify(hours ~ age) %>% 
    generate(reps = 1000, type = "bootstrap") %>%
    calculate(stat = "correlation")
@@ -1546,26 +1544,25 @@ boot <- gss %>%
 Use the bootstrap distribution to find a confidence interval,
 
 ```{r}
-percentile_ci <- get_ci(boot)
+percentile_ci <- get_ci(boot_dist)
 ```
 
 Visualizing the observed statistic alongside the distribution,
 
 ```{r}
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = percentile_ci)
 ```
 
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- boot %>%
+standard_error_ci <- boot_dist %>%
   get_ci(type = "se", point_estimate = correlation_hat)
 
-visualize(boot) +
+visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)
 ```
-
 
 ### Two numerical vars - t
 
@@ -1584,7 +1581,7 @@ obs_fit <- gss %>%
 Generating a distribution of fits with the response variable permuted,
 
 ```{r}
-null_distn <- gss %>%
+null_dist <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -1594,7 +1591,7 @@ null_distn <- gss %>%
 Alternatively, generating a distribution of fits where each explanatory variable is permuted independently,
 
 ```{r}
-null_distn2 <- gss %>%
+null_dist2 <- gss %>%
   specify(hours ~ age + college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute", variables = c(age, college)) %>%
@@ -1606,7 +1603,7 @@ Calculating confidence intervals from the null fits,
 ```{r}
 conf_ints <- 
   get_confidence_interval(
-    null_distn, 
+    null_dist, 
     level = .95, 
     point_estimate = obs_fit
   )
@@ -1615,7 +1612,7 @@ conf_ints <-
 Visualizing the observed fit alongside the null fits,
 
 ```{r}
-visualize(null_distn) +
+visualize(null_dist) +
   shade_confidence_interval(endpoints = conf_ints)
 ```
 

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -110,7 +110,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(response = hours)  %>%
   assume("t")
 ```
@@ -125,7 +125,7 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = t_bar, direction = "two-sided")
 ```
 
@@ -451,7 +451,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(college ~ sex, success = "no degree") %>%
   assume("z")
 ```
@@ -466,7 +466,7 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = z_hat, direction = "two-sided")
 ```
 
@@ -549,7 +549,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(response = finrela) %>%
   assume("Chisq")
 ```
@@ -564,14 +564,14 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
 Alternatively, visualizing the observed statistic using both of the null distributions,
 
 ```{r}
-visualize(null_dist_theor, method = "both") +
+visualize(null_dist_theory, method = "both") +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -628,7 +628,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(finrela ~ sex) %>%
   assume(distribution = "Chisq")
 ```
@@ -643,7 +643,7 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = Chisq_hat, direction = "greater")
 ```
 
@@ -744,7 +744,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
   specify(age ~ college) %>%
   assume("t")
 ```
@@ -759,7 +759,7 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = t_hat, direction = "two-sided")
 ```
 
@@ -853,7 +853,7 @@ null_dist <- gss %>%
 Alternatively, finding the null distribution using theoretical methods using the `assume()` verb,
 
 ```{r}
-null_dist_theor <- gss %>%
+null_dist_theory <- gss %>%
    specify(age ~ partyid) %>%
    hypothesize(null = "independence") %>%
    assume(distribution = "F")
@@ -869,7 +869,7 @@ visualize(null_dist) +
 Alternatively, visualizing the observed statistic using the theory-based null distribution,
 
 ```{r}
-visualize(null_dist_theor) +
+visualize(null_dist_theory) +
   shade_p_value(obs_stat = F_hat, direction = "greater")
 ```
 

--- a/vignettes/observed_stat_examples.Rmd
+++ b/vignettes/observed_stat_examples.Rmd
@@ -1065,7 +1065,7 @@ visualize(boot_dist) +
 Alternatively, use the bootstrap distribution to find a confidence interval using the standard error,
 
 ```{r}
-standard_error_ci <- get_ci(boot, type = "se", point_estimate = x_bar)
+standard_error_ci <- get_ci(boot_dist, type = "se", point_estimate = x_bar)
 
 visualize(boot_dist) +
   shade_confidence_interval(endpoints = standard_error_ci)

--- a/vignettes/t_test.Rmd
+++ b/vignettes/t_test.Rmd
@@ -64,7 +64,7 @@ We can `generate` the null distribution using the bootstrap. In the bootstrap, f
 
 ```{r generate-null-1-sample, warning = FALSE, message = FALSE}
 # generate the null distribution
-null_distribution_1_sample <- gss %>%
+null_dist_1_sample <- gss %>%
   specify(response = hours) %>%
   hypothesize(null = "point", mu = 40) %>%
   generate(reps = 1000, type = "bootstrap") %>%
@@ -75,7 +75,7 @@ To get a sense for what these distributions look like, and where our observed st
 
 ```{r visualize-1-sample, warning = FALSE, message = FALSE}
 # visualize the null distribution and test statistic!
-null_distribution_1_sample %>%
+null_dist_1_sample %>%
   visualize() + 
   shade_p_value(observed_statistic,
                 direction = "two-sided")
@@ -85,7 +85,7 @@ It looks like our observed mean of `r observed_statistic` would be relatively un
 
 ```{r p-value-1-sample, warning = FALSE, message = FALSE}
 # calculate the p value from the test statistic and null distribution
-p_value_1_sample <- null_distribution_1_sample %>%
+p_value_1_sample <- null_dist_1_sample %>%
   get_p_value(obs_stat = observed_statistic,
               direction = "two-sided")
 
@@ -168,7 +168,7 @@ We can `generate` the null distribution using permutation, where, for each repli
 
 ```{r generate-null-2-sample, warning = FALSE, message = FALSE}
 # generate the null distribution with randomization
-null_distribution_2_sample <- gss %>%
+null_dist_2_sample <- gss %>%
   specify(hours ~ college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "permute") %>%
@@ -181,7 +181,7 @@ To get a sense for what these distributions look like, and where our observed st
 
 ```{r visualize-2-sample, warning = FALSE, message = FALSE}
 # visualize the randomization-based null distribution and test statistic!
-null_distribution_2_sample %>%
+null_dist_2_sample %>%
   visualize() + 
   shade_p_value(observed_statistic,
                 direction = "two-sided")
@@ -192,7 +192,7 @@ It looks like our observed statistic of `r observed_statistic` would be unlikely
 ```{r p-value-2-sample, warning = FALSE, message = FALSE}
 # calculate the p value from the randomization-based null 
 # distribution and the observed statistic
-p_value_2_sample <- null_distribution_2_sample %>%
+p_value_2_sample <- null_dist_2_sample %>%
   get_p_value(obs_stat = observed_statistic,
               direction = "two-sided")
 


### PR DESCRIPTION
Closes #406.

Some of the more substantive search + replaces:

* `*_distr` -> `*_dist`
* `*_distn` -> `*_dist`
* `*_simulated` -> `*_sim`
* `*_theoretical` -> `*_theor`
* `boot `-> `boot_dist`
* `*distribution*` -> `*dist*`

One thing I'm still unsure on: what should we call a set (distribution?) of models fitted following permutation? These are currently called `null_fits` and referred to as distributions.

This PR leaves `docs/` alone—will regenerate during release prep!
