### PR TITLE
re-license to MIT

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 README_files/
 ^pkgdown$
 ^\.github$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Authors@R:
 Description: The objective of this package is to perform
     inference using an expressive statistical grammar that coheres with
     the tidy design framework.
-License: CC0
+License: MIT + file LICENSE
 URL: https://github.com/tidymodels/infer,
     https://infer.tidymodels.org/
 BugReports: https://github.com/tidymodels/infer/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2021
+COPYRIGHT HOLDER: infer authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 infer authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi all,

This PR would re-license {infer} to use the MIT license to bring the package's licensing in line with other packages in the tidymodels, conform to a license approved by the Journal of Open Source Software, and make the package license as clear and permissive as possible. To do so, we need the approval of all copyright holders. I've tagged those listed as a [contributor](https://github.com/tidymodels/infer/graphs/contributors) of significant changes via GitHub's contributor graphs.

@andrewpbray, @ismayc, @echasnovski, @beanumber, @mine-cetinkaya-rundel, @rudeboybert, @richierocks, @jayleetx, @nicksolomon, @PirateGrunt, @jimrothstein would you permit re-licensing infer from CC0 to the MIT license? If so, please comment "I agree" below.

* [x] @andrewpbray 
* [x] @ismayc
* [x] @echasnovski
* [x] @beanumber 
* [x] @mine-cetinkaya-rundel 
* [x] @rudeboybert 
* [x] @richierocks 
* [x] @jayleetx 
* [x] @nicksolomon 
* [x] @PirateGrunt 
* [x] @jimrothstein

Much appreciated!