### PR TITLE
improve docs re: `set.seed` and reproducibility

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@ README_files/
 ^pkgdown$
 ^\.github$
 ^LICENSE\.md$
+^man-roxygen$

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -37,6 +37,7 @@
 #' cases will be NaN. The package will omit non-finite values from
 #' visualizations (with a warning) and raise an error in p-value calculations.
 #'
+#' @includeRmd man-roxygen/seeds.Rmd
 #' 
 #' @examples
 #'

--- a/R/fit.R
+++ b/R/fit.R
@@ -72,6 +72,8 @@ generics::fit
 #' multivariate analysis of variance and regression" (Marti J. Anderson,
 #' 2001), \doi{10.1139/cjfas-58-3-626}.
 #' 
+#' @includeRmd man-roxygen/seeds.Rmd
+#' 
 #' @examples
 #' # fit a linear model predicting number of hours worked per
 #' # week using respondent age and degree status.

--- a/R/generate.R
+++ b/R/generate.R
@@ -41,6 +41,8 @@
 #'   generation type was previously called `"simulate"`, which has been
 #'   superseded.
 #' }
+#' 
+#' @includeRmd man-roxygen/seeds.Rmd
 #'
 #' @examples
 #' # generate a null distribution by taking 200 bootstrap samples

--- a/man-roxygen/seeds.Rmd
+++ b/man-roxygen/seeds.Rmd
@@ -1,6 +1,6 @@
 # Reproducibility
 
-When using the infer package for research, or in other cases when exact reproducibility is a priority, be sure the set the seed for R's random number generator. infer will respect the random seed specified in the `set.seed()` function, returning the same results when `generate()`ing new data given an identical seed. For instance, we can calculate the difference in mean `age` by `college` degree status using the `gss` dataset from 10 versions of the `gss` resampled with permutation using the following code.
+When using the infer package for research, or in other cases when exact reproducibility is a priority, be sure the set the seed for R's random number generator. infer will respect the random seed specified in the `set.seed()` function, returning the same result when `generate()`ing data given an identical seed. For instance, we can calculate the difference in mean `age` by `college` degree status using the `gss` dataset from 10 versions of the `gss` resampled with permutation using the following code.
 
 ```{r, include = FALSE}
 library(infer)

--- a/man-roxygen/seeds.Rmd
+++ b/man-roxygen/seeds.Rmd
@@ -16,7 +16,7 @@ gss %>%
   calculate("diff in means", order = c("degree", "no degree"))
 ```
 
-Setting the seed again and rerunning the same code will result in the same answer.
+Setting the seed to the same value again and rerunning the same code will produce the same result.
 
 ```{r}
 # set the seed

--- a/man-roxygen/seeds.Rmd
+++ b/man-roxygen/seeds.Rmd
@@ -1,0 +1,32 @@
+# Reproducibility
+
+When using the infer package for research, or in other cases when exact reproducibility is a priority, be sure the set the seed for R's random number generator. infer will respect the random seed specified in the `set.seed()` function, returning the same results when `generate()`ing new data given an identical seed. For instance, we can calculate the difference in mean `age` by `college` degree status using the `gss` dataset from 10 versions of the `gss` resampled with permutation using the following code.
+
+```{r, include = FALSE}
+library(infer)
+```
+
+```{r}
+set.seed(1)
+
+gss %>%
+  specify(age ~ college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 5, type = "permute") %>%
+  calculate("diff in means", order = c("degree", "no degree"))
+```
+
+Setting the seed again and rerunning the same code will result in the same answer.
+
+```{r}
+# set the seed
+set.seed(1)
+
+gss %>%
+  specify(age ~ college) %>%
+  hypothesize(null = "independence") %>%
+  generate(reps = 5, type = "permute") %>%
+  calculate("diff in means", order = c("degree", "no degree"))
+```
+
+Please keep this in mind when writing infer code that utilizes resampling with `generate()`.

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -84,8 +84,8 @@ gss \%>\%
 ## 5         5  0.350
 }
 
-Setting the seed again and rerunning the same code will result in the
-same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+Setting the seed to the same value again and rerunning the same code
+will produce the same result.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
 set.seed(1)
 
 gss \%>\%

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -56,6 +56,60 @@ cases will be NaN. The package will omit non-finite values from
 visualizations (with a warning) and raise an error in p-value calculations.
 }
 
+\section{Reproducibility}{
+When using the infer package for research, or in other cases when exact
+reproducibility is a priority, be sure the set the seed for R’s random
+number generator. infer will respect the random seed specified in the
+\code{set.seed()} function, returning the same results when \code{generate()}ing
+new data given an identical seed. For instance, we can calculate the
+difference in mean \code{age} by \code{college} degree status using the \code{gss}
+dataset from 10 versions of the \code{gss} resampled with permutation using
+the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Setting the seed again and rerunning the same code will result in the
+same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Please keep this in mind when writing infer code that utilizes
+resampling with \code{generate()}.
+}
+
 \examples{
 
 # calculate a null distribution of hours worked per week under

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -60,8 +60,8 @@ visualizations (with a warning) and raise an error in p-value calculations.
 When using the infer package for research, or in other cases when exact
 reproducibility is a priority, be sure the set the seed for R’s random
 number generator. infer will respect the random seed specified in the
-\code{set.seed()} function, returning the same results when \code{generate()}ing
-new data given an identical seed. For instance, we can calculate the
+\code{set.seed()} function, returning the same result when \code{generate()}ing
+data given an identical seed. For instance, we can calculate the
 difference in mean \code{age} by \code{college} degree status using the \code{gss}
 dataset from 10 versions of the \code{gss} resampled with permutation using
 the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -71,6 +71,60 @@ exist. For an overview, see "Permutation tests for univariate or
 multivariate analysis of variance and regression" (Marti J. Anderson,
 2001), \doi{10.1139/cjfas-58-3-626}.
 }
+\section{Reproducibility}{
+When using the infer package for research, or in other cases when exact
+reproducibility is a priority, be sure the set the seed for R’s random
+number generator. infer will respect the random seed specified in the
+\code{set.seed()} function, returning the same results when \code{generate()}ing
+new data given an identical seed. For instance, we can calculate the
+difference in mean \code{age} by \code{college} degree status using the \code{gss}
+dataset from 10 versions of the \code{gss} resampled with permutation using
+the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Setting the seed again and rerunning the same code will result in the
+same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Please keep this in mind when writing infer code that utilizes
+resampling with \code{generate()}.
+}
+
 \examples{
 # fit a linear model predicting number of hours worked per
 # week using respondent age and degree status.

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -75,8 +75,8 @@ multivariate analysis of variance and regression" (Marti J. Anderson,
 When using the infer package for research, or in other cases when exact
 reproducibility is a priority, be sure the set the seed for R’s random
 number generator. infer will respect the random seed specified in the
-\code{set.seed()} function, returning the same results when \code{generate()}ing
-new data given an identical seed. For instance, we can calculate the
+\code{set.seed()} function, returning the same result when \code{generate()}ing
+data given an identical seed. For instance, we can calculate the
 difference in mean \code{age} by \code{college} degree status using the \code{gss}
 dataset from 10 versions of the \code{gss} resampled with permutation using
 the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)

--- a/man/fit.infer.Rd
+++ b/man/fit.infer.Rd
@@ -99,8 +99,8 @@ gss \%>\%
 ## 5         5  0.350
 }
 
-Setting the seed again and rerunning the same code will result in the
-same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+Setting the seed to the same value again and rerunning the same code
+will produce the same result.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
 set.seed(1)
 
 gss \%>\%

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -55,6 +55,60 @@ superseded.
 }
 }
 
+\section{Reproducibility}{
+When using the infer package for research, or in other cases when exact
+reproducibility is a priority, be sure the set the seed for R’s random
+number generator. infer will respect the random seed specified in the
+\code{set.seed()} function, returning the same results when \code{generate()}ing
+new data given an identical seed. For instance, we can calculate the
+difference in mean \code{age} by \code{college} degree status using the \code{gss}
+dataset from 10 versions of the \code{gss} resampled with permutation using
+the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Setting the seed again and rerunning the same code will result in the
+same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+set.seed(1)
+
+gss \%>\%
+  specify(age ~ college) \%>\%
+  hypothesize(null = "independence") \%>\%
+  generate(reps = 5, type = "permute") \%>\%
+  calculate("diff in means", order = c("degree", "no degree"))
+}\if{html}{\out{</div>}}\preformatted{## Response: age (numeric)
+## Explanatory: college (factor)
+## Null Hypothesis: independence
+## # A tibble: 5 × 2
+##   replicate   stat
+##       <int>  <dbl>
+## 1         1 -0.531
+## 2         2 -2.35 
+## 3         3  0.764
+## 4         4  0.280
+## 5         5  0.350
+}
+
+Please keep this in mind when writing infer code that utilizes
+resampling with \code{generate()}.
+}
+
 \examples{
 # generate a null distribution by taking 200 bootstrap samples
 gss \%>\%

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -59,8 +59,8 @@ superseded.
 When using the infer package for research, or in other cases when exact
 reproducibility is a priority, be sure the set the seed for R’s random
 number generator. infer will respect the random seed specified in the
-\code{set.seed()} function, returning the same results when \code{generate()}ing
-new data given an identical seed. For instance, we can calculate the
+\code{set.seed()} function, returning the same result when \code{generate()}ing
+data given an identical seed. For instance, we can calculate the
 difference in mean \code{age} by \code{college} degree status using the \code{gss}
 dataset from 10 versions of the \code{gss} resampled with permutation using
 the following code.\if{html}{\out{<div class="r">}}\preformatted{set.seed(1)

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -83,8 +83,8 @@ gss \%>\%
 ## 5         5  0.350
 }
 
-Setting the seed again and rerunning the same code will result in the
-same answer.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
+Setting the seed to the same value again and rerunning the same code
+will produce the same result.\if{html}{\out{<div class="r">}}\preformatted{# set the seed
 set.seed(1)
 
 gss \%>\%

--- a/vignettes/infer.Rmd
+++ b/vignettes/infer.Rmd
@@ -126,7 +126,7 @@ gss %>%
 
 In the above example, we take 1000 bootstrap samples to form our null distribution.
 
-Note that, before `generate()`ing, we've set the seed for random number generation with the `set.seed()` function. When using the infer package for research, or in other cases when exact reproducibility is a priority, this is good practice. infer will respect the random seed specified in the `set.seed()` function, returning the same results when `generate()`ing new data given an identical seed.
+Note that, before `generate()`ing, we've set the seed for random number generation with the `set.seed()` function. When using the infer package for research, or in other cases when exact reproducibility is a priority, this is good practice. infer will respect the random seed specified in the `set.seed()` function, returning the same result when `generate()`ing data given an identical seed.
 
 To generate a null distribution for the independence of two variables, we could also randomly reshuffle the pairings of explanatory and response variables to break any existing association. For instance, to generate 1000 replicates that can be used to create a null distribution under the assumption that political party affiliation is not affected by age:
 

--- a/vignettes/infer.Rmd
+++ b/vignettes/infer.Rmd
@@ -116,6 +116,8 @@ Once we've asserted our null hypothesis using `hypothesize()`, we can construct 
 Continuing on with our example above, about the average number of hours worked a week, we might write:
 
 ```{r generate-point, warning = FALSE, message = FALSE}
+set.seed(1)
+
 gss %>%
   specify(response = hours) %>%
   hypothesize(null = "point", mu = 40) %>%
@@ -123,6 +125,8 @@ gss %>%
 ```
 
 In the above example, we take 1000 bootstrap samples to form our null distribution.
+
+Note that, before `generate()`ing, we've set the seed for random number generation with the `set.seed()` function. When using the infer package for research, or in other cases when exact reproducibility is a priority, this is good practice. infer will respect the random seed specified in the `set.seed()` function, returning the same results when `generate()`ing new data given an identical seed.
 
 To generate a null distribution for the independence of two variables, we could also randomly reshuffle the pairings of explanatory and response variables to break any existing association. For instance, to generate 1000 replicates that can be used to create a null distribution under the assumption that political party affiliation is not affected by age:
 


### PR DESCRIPTION
This PR adds a section to the docs for `generate` and functions used after `generate()`ing about reproducibility when resampling! Notes that infer respects the state of the RNG and provides an example of how to reproduce exact results.

Worth mentioning that this PR doesn't introduce a more integrated solution to setting the RNG seed, as @kellieotto suggested in #416. I think this avoids introducing an additional layer of abstraction for RNGs (which I find tricky, personally?), though am open to discuss further if folks feel this might be worthwhile.

Closes #416.