### PR TITLE
clarify docs re: `type = "draw"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Re-licensed the package from CC0 to MIT. See the `LICENSE` and `LICENSE.md` files.
 * Contributed a paper to the Journal of Open Source Software, a draft of which is available in `/figs/paper`.
+* Various improvements to documentation (#417, #418).
 
 # infer 1.0.0
 

--- a/R/generate.R
+++ b/R/generate.R
@@ -36,8 +36,8 @@
 #'   \item `permute`: For each replicate, each input value will be randomly
 #'   reassigned (without replacement) to a new output value in the sample.
 #'   \item `draw`: A value will be sampled from a theoretical distribution
-#'   with parameters specified in [hypothesize()] for each replicate. This
-#'   option is currently only applicable for testing point estimates. This
+#'   with parameter `p` specified in [hypothesize()] for each replicate. This
+#'   option is currently only applicable for testing on one proportion. This
 #'   generation type was previously called `"simulate"`, which has been
 #'   superseded.
 #' }
@@ -50,11 +50,19 @@
 #'  generate(reps = 200, type = "bootstrap")
 #'
 #' # generate a null distribution for the independence of
-#' # two variables by permuting their values 1000 times
+#' # two variables by permuting their values 200 times
 #' gss %>%
 #'  specify(partyid ~ age) %>%
 #'  hypothesize(null = "independence") %>%
 #'  generate(reps = 200, type = "permute")
+#' 
+#' # generate a null distribution via sampling from a
+#' # binomial distribution 200 times
+#' gss %>%
+#' specify(response = sex, success = "female") %>%
+#'   hypothesize(null = "point", p = .5) %>%
+#'   generate(reps = 200, type = "draw") %>%
+#'   calculate(stat = "z")
 #'
 #' # more in-depth explanation of how to use the infer package
 #' \dontrun{

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -48,8 +48,8 @@ replacement) from the input sample data.
 \item \code{permute}: For each replicate, each input value will be randomly
 reassigned (without replacement) to a new output value in the sample.
 \item \code{draw}: A value will be sampled from a theoretical distribution
-with parameters specified in \code{\link[=hypothesize]{hypothesize()}} for each replicate. This
-option is currently only applicable for testing point estimates. This
+with parameter \code{p} specified in \code{\link[=hypothesize]{hypothesize()}} for each replicate. This
+option is currently only applicable for testing on one proportion. This
 generation type was previously called \code{"simulate"}, which has been
 superseded.
 }
@@ -63,11 +63,19 @@ gss \%>\%
  generate(reps = 200, type = "bootstrap")
 
 # generate a null distribution for the independence of
-# two variables by permuting their values 1000 times
+# two variables by permuting their values 200 times
 gss \%>\%
  specify(partyid ~ age) \%>\%
  hypothesize(null = "independence") \%>\%
  generate(reps = 200, type = "permute")
+
+# generate a null distribution via sampling from a
+# binomial distribution 200 times
+gss \%>\%
+specify(response = sex, success = "female") \%>\%
+  hypothesize(null = "point", p = .5) \%>\%
+  generate(reps = 200, type = "draw") \%>\%
+  calculate(stat = "z")
 
 # more in-depth explanation of how to use the infer package
 \dontrun{


### PR DESCRIPTION
Specifies that only testing on one proportion is supported in the `type = "draw"` option and adds an example to the `generate` docs. Also, makes a small update to `NEWS` for this and the last PR.

Closes #415.