### PR TITLE
add CITATION file

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,12 @@
+bibentry(
+  "Article",
+  title     = "{infer}: An {R} package for tidyverse-friendly statistical inference",
+  author    = "Simon P. Couch, Andrew P. Bray, Chester Ismay, Evgeni Chasnovski, Benjamin S. Baumer, Mine Çetinkaya-Rundel",
+  journal   = "Journal of Open Source Software",
+  year      = 2021,
+  volume    = 6,
+  number    = 65,
+  pages     = 3661,
+  doi       = "10.21105/joss.03661",
+  textVersion = "Couch et al., (2021). infer: An R package for tidyverse-friendly statistical inference. Journal of Open Source Software, 6(65), 3661, https://doi.org/10.21105/joss.03661"
+)


### PR DESCRIPTION
Our submission to JOSS was accepted!🎊 https://joss.theoj.org/papers/10.21105/joss.03661#

This PR adds the JOSS citation to the CITATION file. I just worked from `devtools::use_citation()` and pattern-matching [the tidyverse's entry](https://github.com/tidyverse/tidyverse/blob/master/inst/CITATION) to fill in the citation info from JOSS. The output looks like this:

```
> citation("infer")

  Couch et al., (2021). infer: An R package for tidyverse-friendly statistical
  inference. Journal of Open Source Software, 6(65), 3661,
  https://doi.org/10.21105/joss.03661

A BibTeX entry for LaTeX users is

  @Article{,
    title = {{infer}: An {R} package for tidyverse-friendly statistical inference},
    author = {Simon P. Couch and Andrew P. Bray and Chester Ismay and Evgeni Chasnovski and Benjamin S. Baumer and Mine Çetinkaya-Rundel},
    journal = {Journal of Open Source Software},
    year = {2021},
    volume = {6},
    number = {65},
    pages = {3661},
    doi = {10.21105/joss.03661},
  }
```