### PR TITLE
unify standardization of variable types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,8 @@ Imports:
     broom,
     tidyr,
     generics,
-    patchwork
+    patchwork,
+    tidyselect
 Suggests:
     covr,
     devtools (>= 1.12.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ To be released as v1.0.2.
 * Fix `generate()` errors when columns are named `x` (#431).
 * Fix error from `visualize` when passed `generate()`d `infer_dist` objects that had not been passed to `hypothesize()` (#432). 
 * Update visual checks for `visualize` output to align with the R 4.1.0+ graphics engine (#438).
+* `specify()` and wrapper functions now appropriately handle ordered factors (#439).
 
 # infer v1.0.1 (GitHub Only)
 

--- a/R/infer.R
+++ b/R/infer.R
@@ -23,7 +23,7 @@ if (getRversion() >= "2.15.1") {
       "denom", "diff_prop", "group_num", "n1", "n2", "num_suc", "p_hat",
       "total_suc", "explan", "probs", "conf.low", "conf.high", "prop_1",
       "prop_2", "data", "setNames", "resp", "capture.output", "stats",
-      "estimate", "any_of", "model", "term"
+      "estimate", "any_of", "model", "term", "where"
     )
   )
 }

--- a/R/specify.R
+++ b/R/specify.R
@@ -42,7 +42,7 @@
 #' }
 #'
 #' @importFrom rlang f_lhs f_rhs get_expr
-#' @importFrom dplyr mutate_if select any_of
+#' @importFrom dplyr select any_of across
 #' @importFrom methods hasArg
 #' @family core functions
 #' @export
@@ -51,10 +51,7 @@ specify <- function(x, formula, response = NULL,
   check_type(x, is.data.frame)
 
   # Standardize variable types
-  x <- tibble::as_tibble(x) %>%
-    mutate_if(is.character, as.factor) %>%
-    mutate_if(is.logical, as.factor) %>%
-    mutate_if(is.integer, as.numeric)
+  x <- standardize_variable_types(x)
   
   # Parse response and explanatory variables
   response <- enquo(response)

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,6 +69,22 @@ reorder_explanatory <- function(x, order) {
   x
 }
 
+standardize_variable_types <- function(x) {
+  tibble::as_tibble(x) %>%
+    dplyr::mutate(
+      dplyr::across(
+        where(~ is.character(.x) || is.logical(.x) || is.ordered(.x)),
+        ~ factor(.x, ordered = FALSE)
+      )
+    ) %>%
+    dplyr::mutate(
+      dplyr::across(
+        where(is.integer), 
+        as.numeric
+      )
+    )
+}
+
 # Getters, setters, and indicators ------------------------------------------
 explanatory_expr <- function(x) {
   attr(x, "explanatory")

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -61,9 +61,7 @@ t_test <- function(x, formula,
   check_conf_level(conf_level)
 
   # convert all character and logical variables to be factor variables
-  x <- tibble::as_tibble(x) %>%
-    mutate_if(is.character, as.factor) %>%
-    mutate_if(is.logical, as.factor)
+  x <- standardize_variable_types(x)
 
   # parse response and explanatory variables
   response    <- enquo(response)
@@ -176,9 +174,7 @@ t_stat <- function(x, formula,
   check_conf_level(conf_level)
 
   # convert all character and logical variables to be factor variables
-  x <- tibble::as_tibble(x) %>%
-    mutate_if(is.character, as.factor) %>%
-    mutate_if(is.logical, as.factor)
+  x <- standardize_variable_types(x)
 
   # parse response and explanatory variables
   response    <- enquo(response)
@@ -260,6 +256,9 @@ chisq_test <- function(x, formula, response = NULL,
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
+  
+  x <- standardize_variable_types(x)
+  
   x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
 
@@ -278,9 +277,7 @@ chisq_test <- function(x, formula, response = NULL,
   }
 
   x <- x %>%
-    select(any_of(c(response_name(x), explanatory_name(x)))) %>%
-    mutate_if(is.character, as.factor) %>%
-    mutate_if(is.logical, as.factor)
+    select(any_of(c(response_name(x), explanatory_name(x))))
 
   stats::chisq.test(table(x), ...) %>%
     broom::glance() %>%
@@ -337,6 +334,8 @@ chisq_stat <- function(x, formula, response = NULL,
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
+  x <- standardize_variable_types(x)
+  
   x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
 
@@ -355,9 +354,7 @@ chisq_stat <- function(x, formula, response = NULL,
   }
 
   x <- x %>%
-    select(any_of(c(response_name(x), explanatory_name(x)))) %>%
-    mutate_if(is.character, as.factor) %>%
-    mutate_if(is.logical, as.factor)
+    select(any_of(c(response_name(x), explanatory_name(x))))
 
   suppressWarnings(stats::chisq.test(table(x), ...)) %>%
     broom::glance() %>%
@@ -460,8 +457,11 @@ prop_test <- function(x, formula,
   # Parse response and explanatory variables
   response    <- enquo(response)
   explanatory <- enquo(explanatory)
+  x <- standardize_variable_types(x)
+  
   x <- parse_variables(x = x, formula = formula,
                        response = response, explanatory = explanatory)
+  
   correct <- if (z) {FALSE} else if (is.null(correct)) {TRUE} else {correct}
 
   if (!(class(response_variable(x)) %in% c("logical", "character", "factor"))) {
@@ -505,8 +505,6 @@ prop_test <- function(x, formula,
     # make a summary table to supply to prop.test
     sum_table <- x %>%
       select(response_name(x), explanatory_name(x)) %>%
-      mutate_if(is.character, as.factor) %>%
-      mutate_if(is.logical, as.factor) %>%
       table()
 
     # reorder according to the order and success arguments

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -413,3 +413,41 @@ test_that("prop_test z argument works as expected", {
     
   expect_equal(unname(chi_res$statistic), z_res$statistic^2, tolerance = eps)
 })
+
+test_that("wrappers can handled ordered factors", {
+  expect_equal(
+    gss_tbl %>%
+      dplyr::mutate(sex = factor(sex, ordered = FALSE)) %>%
+      t_test(hours ~ sex, order = c("male", "female")),
+    gss_tbl %>%
+      dplyr::mutate(sex = factor(sex, ordered = TRUE)) %>%
+      t_test(hours ~ sex, order = c("male", "female"))
+  )
+  
+  expect_equal(
+    gss_tbl %>%
+      dplyr::mutate(income = factor(income, ordered = TRUE)) %>%
+      chisq_test(income ~ partyid),
+    gss_tbl %>%
+      dplyr::mutate(income = factor(income, ordered = FALSE)) %>%
+      chisq_test(income ~ partyid)
+  )
+  
+  expect_equal(
+    gss_tbl %>%
+      dplyr::mutate(income = factor(income, ordered = TRUE)) %>%
+      chisq_test(partyid ~ income),
+    gss_tbl %>%
+      dplyr::mutate(income = factor(income, ordered = FALSE)) %>%
+      chisq_test(partyid ~ income)
+  )
+  
+  expect_equal(
+    df %>%
+      dplyr::mutate(resp = factor(resp, ordered = TRUE)) %>%
+      prop_test(resp ~ NULL, p = .5),
+    df %>%
+      dplyr::mutate(resp = factor(resp, ordered = FALSE)) %>%
+      prop_test(resp ~ NULL, p = .5)
+  )
+})


### PR DESCRIPTION
Closes #436. [EDIT: corrected linked issue.]

This PR switches out ad-hoc standardization of variables types with a `standardize_variable_types` utility that, for the most part, does what the ad-hoc standardization did previously, but also enables `specify` and wrappers to handle ordered factors. 