### PR TITLE
skip check_cols in gennerate when type = 'bootstrap'

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -86,7 +86,9 @@ generate <- function(x, reps = 1, type = NULL,
   }
   attr(x, "type") <- type
 
-  check_cols(x, rlang::enquo(variables), type, missing(variables))
+  if(type != "bootstrap") {
+    check_cols(x, rlang::enquo(variables), type, missing(variables))
+  }
 
   attr(x, "generated") <- TRUE
 


### PR DESCRIPTION
When type = "bootstrap", the variable parameter is not required? According to the existing code, executing this statement will report an error `generate(mtcars, reps = 10, type =  'bootstrap')` So I made changes to skip check_cols when type = "bootstrap"