### PR TITLE
prompt on `null == "point"` with an explanatory variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ To be released as v1.0.2.
 * Fix error from `visualize` when passed `generate()`d `infer_dist` objects that had not been passed to `hypothesize()` (#432). 
 * Update visual checks for `visualize` output to align with the R 4.1.0+ graphics engine (#438).
 * `specify()` and wrapper functions now appropriately handle ordered factors (#439).
+* Clarify error when supplied `null = "point"` with an explanatory variable (#441). 
 
 # infer v1.0.1 (GitHub Only)
 

--- a/R/hypothesize.R
+++ b/R/hypothesize.R
@@ -97,6 +97,13 @@ hypothesize_checks <- function(x, null) {
       'testing a null hypothesis of `"independence"`.'
     )
   }
+  
+  if ((null == "point") && has_explanatory(x)) {
+    stop_glue(
+      'Please `specify()` only a response variable when ',
+      'testing a `"point"` null hypothesis.'
+    )
+  }
 }
 
 match_null_hypothesis <- function(null) {

--- a/tests/testthat/test-hypothesize.R
+++ b/tests/testthat/test-hypothesize.R
@@ -116,6 +116,26 @@ test_that(
 })
 
 test_that(
+  "hypothesize() errors on independence null with no explanatory variable", {
+    expect_error(
+      gss %>%
+        specify(response = college, success = "degree") %>%
+        hypothesize(null = "independence"),
+      'Please \\`specify\\(\\)\\` an explanatory and a response variable'
+    )
+  })
+
+test_that(
+  "hypothesize() errors on point null with an explanatory variable", {
+    expect_error(
+      gss %>%
+        specify(college ~ sex, success = "degree") %>%
+        hypothesize(null = "point", p = .40),
+      'Please \\`specify\\(\\)\\` only a response variable'
+    )
+  })
+
+test_that(
   "hypothesize() throws an error when p is greater than 1", {
   expect_error(
     mtcars_df %>%


### PR DESCRIPTION
Closes #441.🐣

Followed the lead of code that checks for the opposite—`null = "independence"` with no explanatory variable—in determining that this should be an _error_ and locating where the prompt is raised.

Also added a test for the previous functionality as I couldn't find an existing one.

One thing I'd appreciate an eye for: am I overlooking a case when `null = "point"` with an explanatory variable makes sense? Should this be a warning instead?