### PR TITLE
clarify dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,8 +90,7 @@ Imports:
     broom,
     tidyr,
     generics,
-    patchwork,
-    tidyselect
+    patchwork
 Suggests:
     covr,
     devtools (>= 1.12.0),
@@ -101,7 +100,8 @@ Suggests:
     rmarkdown,
     stringr,
     testthat,
-    vdiffr (>= 1.0.0)
+    vdiffr (>= 1.0.0),
+    parsnip
 VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate


### PR DESCRIPTION
addresses recent check NOTEs:

```
❯ checking dependencies in R code ... NOTE
  Namespace in Imports field not imported from: ‘tidyselect’
    All declared Imports should be used.

❯ checking Rd cross-references ... NOTE
  Package unavailable to check Rd xrefs: ‘parsnip’
```