### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,7 +8,6 @@
 ^codecov\.yml$
 ^docs*
 ^CONDUCT\.md$
-^README\.md$
 ^cran-comments\.md$
 ^_build\.sh$
 ^appveyor\.yml$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.