### PR TITLE
Update rep_sample_n.R

### DIFF
--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -121,7 +121,7 @@ rep_slice_sample <- function(.data, n = NULL, prop = NULL, replace = FALSE,
   check_type(replace, is_truefalse, "TRUE or FALSE")
   check_type(
     weight_by,
-    ~ is.numeric(.) && (length(.) == nrow(.data)),
+    ~ (length(.) == nrow(.data)),
     glue::glue("numeric vector with length `nrow(.data)` = {nrow(.data)}"),
     allow_null = TRUE
   )


### PR DESCRIPTION
See #480 .

This simply removes the check that the `weight_by` is a numeric vector.

I'm trying to replicate the checks done in `dplyr::slice_sample()` on `weight_by`. This is in <https://github.com/tidyverse/dplyr/blob/main/R/slice.R#L321>.

<img width="400" alt="Screen Shot 2023-03-07 at 1 17 11 PM" src="https://user-images.githubusercontent.com/1627362/223555336-0b5511cf-02e0-491a-bc30-35f528f6d6e2.png">

It looks like all they do is a length check on the vector and then pass it along to `sample_int()`.

<img width="400" alt="Screen Shot 2023-03-07 at 1 17 48 PM" src="https://user-images.githubusercontent.com/1627362/223555456-04426438-0847-4c13-a2f7-8f31ff6b0ae5.png">

Which passes it along to `sample.int()`.
