### PR TITLE
allow unquoted column name for `weight_by` in `rep_slice_sample()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # infer v1.0.4.9000 (developmental version)
 
+* The `weight_by` argument to `rep_slice_sample()` can now be passed either as a vector of numeric weights or an unquoted column name in `.data` (#480).
+
 # infer v1.0.4
 
 * Fixed bug in p-value shading where shaded regions no longer correctly overlaid

--- a/R/generate.R
+++ b/R/generate.R
@@ -174,17 +174,17 @@ check_permutation_attributes <- function(x, attr) {
   }
 }
 
-check_cols <- function(x, variables, type, missing) {
+check_cols <- function(x, variables, type, missing, arg_name = "variables") {
   if (!rlang::is_symbolic(rlang::get_expr(variables))) {
     stop_glue(
-      "The `variables` argument should be one or more unquoted variable names ",
+      "The `{arg_name}` argument should be one or more unquoted variable names ",
       "(not strings in quotation marks)."
     )
   }
 
   if (!missing && type != "permute") {
     warning_glue(
-      'The `variables` argument is only relevant for the "permute" ',
+      'The `{arg_name}` argument is only relevant for the "permute" ',
       'generation type and will be ignored.'
     )
 
@@ -205,7 +205,7 @@ check_cols <- function(x, variables, type, missing) {
 
     stop_glue(
       'The column{plurals[1]} `{list(bad_cols)}` provided to ',
-      'the `variables` argument {plurals[2]} not in the supplied data.'
+      'the `{arg_name}` argument {plurals[2]} not in the supplied data.'
     )
   }
 }

--- a/man/rep_sample_n.Rd
+++ b/man/rep_sample_n.Rd
@@ -32,7 +32,8 @@ not an integer. When using \code{rep_slice_sample()}, please only supply one of
 \item{reps}{Number of samples to take.}
 
 \item{prob, weight_by}{A vector of sampling weights for each of the rows in
-\code{.data}—must have length equal to \code{nrow(.data)}.}
+\code{.data}—must have length equal to \code{nrow(.data)}. For \code{weight_by}, this
+may also be an unquoted column name in \code{.data}.}
 }
 \value{
 A tibble of size \code{reps * n} rows corresponding to \code{reps}
@@ -91,4 +92,9 @@ df <- tibble(
 )
 
 rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
+
+# alternatively, pass an unquoted column name in `.data` as `weight_by`
+df <- df \%>\% mutate(wts = c(.5, .4, .3, .2, .1))
+
+rep_slice_sample(df, n = 2, reps = 5, weight_by = wts)
 }

--- a/tests/testthat/test-rep_sample_n.R
+++ b/tests/testthat/test-rep_sample_n.R
@@ -182,6 +182,10 @@ test_that("`rep_slice_sample` checks input", {
     rep_slice_sample(population, n = 1, weight_by = c(0.1, 0.9)),
     glue::glue("`weight_by`.*length.*{nrow(population)}")
   )
+  expect_error(
+     rep_slice_sample(population, n = 1, weight_by = wts),
+     glue::glue("`wts`.*`weight_by`.*not in the supplied data")
+  )
 
   # `reps`
   expect_error(
@@ -283,7 +287,18 @@ test_that("`rep_slice_sample` uses `weight_by`", {
     weight_by = rep(1, n_population) / n_population
   )
 
+  population_wt <-
+     population %>%
+     dplyr::mutate(wts = rep(1, n_population) / n_population)
+  set.seed(1)
+  res3 <- rep_slice_sample(
+     population_wt,
+     n = n_population,
+     weight_by = wts
+  )
+
   expect_equal(res1[["ball_id"]], res2[["ball_id"]])
+  expect_equal(res1[["ball_id"]], res3[["ball_id"]])
 })
 
 test_that("`rep_slice_sample` uses `reps`", {


### PR DESCRIPTION
Closes #480.🍄

With this PR:

``` r
library(infer)
library(tibble)

df <- tibble(
   id = 1:5,
   letter = factor(c("a", "b", "c", "d", "e")),
   wts = c(.5, .4, .3, .2, .1)
)

set.seed(1)
rep_slice_sample(df, n = 2, reps = 5, weight_by = c(.5, .4, .3, .2, .1))
#> # A tibble: 10 × 4
#> # Groups:   replicate [5]
#>    replicate    id letter   wts
#>        <int> <int> <fct>  <dbl>
#>  1         1     1 a        0.5
#>  2         1     2 b        0.4
#>  3         2     2 b        0.4
#>  4         2     4 d        0.2
#>  5         3     1 a        0.5
#>  6         3     4 d        0.2
#>  7         4     5 e        0.1
#>  8         4     3 c        0.3
#>  9         5     3 c        0.3
#> 10         5     1 a        0.5

set.seed(1)
rep_slice_sample(df, n = 2, reps = 5, weight_by = df$wts)
#> # A tibble: 10 × 4
#> # Groups:   replicate [5]
#>    replicate    id letter   wts
#>        <int> <int> <fct>  <dbl>
#>  1         1     1 a        0.5
#>  2         1     2 b        0.4
#>  3         2     2 b        0.4
#>  4         2     4 d        0.2
#>  5         3     1 a        0.5
#>  6         3     4 d        0.2
#>  7         4     5 e        0.1
#>  8         4     3 c        0.3
#>  9         5     3 c        0.3
#> 10         5     1 a        0.5

set.seed(1)
rep_slice_sample(df, n = 2, reps = 5, weight_by = wts)
#> # A tibble: 10 × 4
#> # Groups:   replicate [5]
#>    replicate    id letter   wts
#>        <int> <int> <fct>  <dbl>
#>  1         1     1 a        0.5
#>  2         1     2 b        0.4
#>  3         2     2 b        0.4
#>  4         2     4 d        0.2
#>  5         3     1 a        0.5
#>  6         3     4 d        0.2
#>  7         4     5 e        0.1
#>  8         4     3 c        0.3
#>  9         5     3 c        0.3
#> 10         5     1 a        0.5

rep_slice_sample(df, n = 2, reps = 5, weight_by = wt)
#> Error: The column `wt` provided to the `weight_by` argument is not in the supplied data.
```

<sup>Created on 2023-03-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>