### PR TITLE
speed up `permute_once()`

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -255,7 +255,8 @@ permute_once <- function(x, variables, ..., call = caller_env()) {
     needs_permuting <- colnames(x) %in% process_variables(variables, FALSE)
 
     # pass each to permute_column with its associated logical
-    out <- purrr::map2_dfc(x, needs_permuting, permute_column)
+    out <- purrr::map2(x, needs_permuting, permute_column)
+    out <- dplyr::bind_cols(out)
 
     copy_attrs(out, x)
   } else {


### PR DESCRIPTION
A 10x speedup for `generate()` in this example!

With `main` dev:

``` r
library(infer)

gss_hyp <- 
   gss %>%
   specify(age ~ college) %>%
   hypothesize(null = "independence")

bench::mark(
   generate = generate(gss_hyp, reps = 1000, type = "permute")
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 generate      2.07s    2.07s     0.482    33.3MB     11.1
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 generate      237ms    242ms      4.15    24.2MB     36.0
```

<sup>Created on 2023-04-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>