### PR TITLE
speed up `group_by(replicate)`

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -269,8 +269,11 @@ calc_impl_one_f <- function(f) {
   function(type, x, order, ...) {
     col <- base::setdiff(names(x), "replicate")
 
+    if (!identical(dplyr::group_vars(x), "replicate")) {
+       x <- dplyr::group_by(x, replicate)
+    }
+
     res <- x %>%
-      dplyr::group_by(replicate) %>%
       dplyr::summarize(stat = f(!!(sym(col)), ...))
 
     # calculate SE for confidence intervals
@@ -299,8 +302,12 @@ calc_impl_success_f <- function(f, output_name) {
     col <- base::setdiff(names(x), "replicate")
 
     success <- attr(x, "success")
+
+    if (!identical(dplyr::group_vars(x), "replicate")) {
+       x <- dplyr::group_by(x, replicate)
+    }
+
     res <- x %>%
-      dplyr::group_by(replicate) %>%
       dplyr::summarize(stat = f(!!sym(col), success))
 
     # calculate SE for confidence intervals

--- a/R/generate.R
+++ b/R/generate.R
@@ -237,10 +237,11 @@ bootstrap <- function(x, reps = 1, ...) {
 
 #' @importFrom dplyr bind_rows group_by
 permute <- function(x, reps = 1, variables, ..., call = caller_env()) {
+  nrow_x <- nrow(x)
   df_out <- replicate(reps, permute_once(x, variables, call = call), simplify = FALSE) %>%
     dplyr::bind_rows() %>%
-    dplyr::mutate(replicate = rep(1:reps, each = nrow(!!x))) %>%
-    dplyr::group_by(replicate)
+    dplyr::mutate(replicate = rep(1:reps, each = !!nrow_x)) %>%
+    group_by_replicate(reps, nrow_x)
 
   df_out <- copy_attrs(to = df_out, from = x)
 
@@ -325,7 +326,7 @@ draw <- function(x, reps = 1, ...) {
 
   rep_tbl <- copy_attrs(to = rep_tbl, from = x)
 
-  rep_tbl <- dplyr::group_by(rep_tbl, replicate)
+  rep_tbl <- group_by_replicate(rep_tbl, reps, nrow(x))
 
   append_infer_class(rep_tbl)
 }

--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -184,7 +184,7 @@ make_replicate_tbl <- function(tbl, size, replace, prob, reps) {
     dplyr::mutate(replicate = rep(seq_len(reps), each = sample_size)) %>%
     dplyr::select(replicate, dplyr::everything()) %>%
     tibble::as_tibble() %>%
-    dplyr::group_by(replicate)
+    group_by_replicate(reps = reps, n = sample_size)
 }
 
 notify_extra_size <- function(size, tbl, replace, notify_type, call = caller_env()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -95,6 +95,31 @@ standardize_variable_types <- function(x) {
       )
 }
 
+# Performant grouping ----------------------------------------------------------
+group_by_replicate <- function(tbl, reps, n) {
+   dplyr::new_grouped_df(
+      tbl,
+      groups = make_replicate_groups(tbl, reps = reps, n = n)
+   )
+}
+
+
+make_replicate_groups <- function(tbl, reps, n) {
+   res <-
+      tibble::new_tibble(vctrs::df_list(
+         replicate = 1:reps,
+         .rows =
+            vctrs::as_list_of(
+               vctrs::vec_chop(seq_len(n*reps), sizes = rep(n, reps)),
+               .ptype = integer()
+            )
+      ))
+
+   attr(res, ".drop") <- TRUE
+
+   res
+}
+
 # Getters, setters, and indicators ------------------------------------------
 explanatory_expr <- function(x) {
   attr(x, "explanatory")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -142,3 +142,20 @@ test_that("variables are standardized as expected", {
 
    expect_equal(levels(gss_std$is_dem), c("TRUE", "FALSE"))
 })
+
+test_that("group_by_replicate() helper returns correct results", {
+   reps <- 500
+   nrow_gss <- nrow(gss)
+
+   gss_gen <-
+      gss %>%
+      specify(age ~ college) %>%
+      hypothesize(null = "independence") %>%
+      generate(reps = reps, type = "permute") %>%
+      dplyr::ungroup()
+
+   expect_equal(
+      dplyr::group_by(gss_gen, replicate),
+      group_by_replicate(gss_gen, reps, nrow_gss)
+   )
+})


### PR DESCRIPTION
infer pipelines spend a good bit of time in `group_by()`, and many of those usages are with `x %>% group_by(replicate)`. Since we know how that `replicate` column is built, we can tap into dplyr's developer interfaces for `group_by()` to speed that computation up quite a bit.

``` r
library(infer)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
   
gss_gen <- 
   gss %>%
   specify(age ~ college) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 100, type = "permute") %>%
   ungroup()

# note `check = TRUE` checks equality of results
bm <- 
   bench::mark(
      old = group_by(gss_gen, replicate),
      new = infer:::group_by_replicate(gss_gen, reps = 100, n = 500),
      check = TRUE
   )

bm
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          1.03ms    1.1ms      872.    1.01MB     24.7
#> 2 new          94.5µs  115.9µs     8504.  404.34KB     71.3

# `old` is ___ times slower than `new`
as.numeric(bm$median[[1]]) / as.numeric(bm$median[[2]])
#> [1] 9.461464
```

<sup>Created on 2023-04-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Putting these changes in context using the longer-running examples from `calculate()`, with `main` dev:

``` r
library(infer)

bench::mark(
   mean = 
      gss %>%
      specify(response = hours) %>%
      hypothesize(null = "point", mu = 40) %>%
      generate(reps = 200, type = "bootstrap") %>%
      calculate(stat = "mean"),
   diff_in_means = 
      gss %>%
      specify(age ~ college) %>%
      hypothesize(null = "independence") %>%
      generate(reps = 200, type = "permute") %>%
      calculate("diff in means", order = c("degree", "no degree")),
   check = FALSE
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mean            18.2ms   21.1ms     48.6     16.4MB     25.3
#> 2 diff_in_means  481.3ms  484.6ms      2.06    13.3MB     27.9
```

With this PR:

``` r
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mean            14.6ms   16.4ms     59.0     14.2MB     27.5
#> 2 diff_in_means  445.9ms  448.4ms      2.23    13.6MB     27.9
```

<sup>Created on 2023-04-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>