### PR TITLE
speed up `generate(type = "draw")`

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -311,9 +311,10 @@ permute_column <- function(col, permute) {
 draw <- function(x, reps = 1, ...) {
   fct_levels <- as.character(unique(response_variable(x)))
 
+  probs <- format_params(x)
   col_simmed <- unlist(replicate(
     reps,
-    sample(fct_levels, size = nrow(x), replace = TRUE, prob = format_params(x)),
+    sample(fct_levels, size = nrow(x), replace = TRUE, prob = probs),
     simplify = FALSE
   ))
 


### PR DESCRIPTION
As of now, the package re-computes `format_params(x)` in each replicate, which accounts for about half of the total evaluation time of the function.

With `main` dev:

``` r
library(infer)

gss_hyp <-
   gss %>%
   specify(response = sex, success = "female") %>%
   hypothesize(null = "point", p = .5)

bench::mark(
   generate = generate(gss_hyp, reps = 1000, type = "draw")
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 generate     58.4ms   61.7ms      15.2    42.5MB     30.4
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 generate     33.5ms   33.5ms      29.9    40.5MB     747.
```

<sup>Created on 2023-04-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>