### PR TITLE
Preserve contrasts matrices

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -237,6 +237,8 @@ bootstrap <- function(x, reps = 1, ...) {
 
 #' @importFrom dplyr bind_rows group_by
 permute <- function(x, reps = 1, variables, ..., call = caller_env()) {
+  contrast_matrices <- purrr::map(x[, explanatory_name(x)], attr, which = "contrasts")
+
   nrow_x <- nrow(x)
   df_out <- replicate(reps, permute_once(x, variables, call = call), simplify = FALSE) %>%
     dplyr::bind_rows() %>%
@@ -245,6 +247,13 @@ permute <- function(x, reps = 1, variables, ..., call = caller_env()) {
 
   df_out <- copy_attrs(to = df_out, from = x)
 
+  df_out[,explanatory_name(x)] <- purrr::map2(.x = df_out[,explanatory_name(x)],
+                                              .y = contrast_matrices,
+                                              function(x, y) {
+                                                 attr(x, "contrasts") <- y
+                                                 return(x)
+                                                }
+                                              )
   append_infer_class(df_out)
 }
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -578,15 +578,34 @@ test_that("Contrast matrices are preserved", {
    # Effect-coded contrasts for a factor with 3 levels
    tmp_ <- gss_tbl %>%
       dplyr::mutate(partyid = as.factor(partyid),
-                    partyid = `contrasts<-`(partyid, value = contr.sum(3))
+                    partyid = `contrasts<-`(partyid,
+                                            value = contr.sum(length(unique(partyid))))
                     )
 
-   contrast_matrix <- attr(tmp_$partyid, "contrasts", exact = TRUE)
+   party_contrast_matrix <- attr(tmp_$partyid, "contrasts", exact = TRUE)
 
    res_ <- tmp_ %>%
       specify(hours ~ partyid) %>%
       hypothesise(null = "independence") %>%
       generate(reps = 2, type = "permute")
 
-   expect_equal(attr(res_$partyid, "contrasts", exact = TRUE), contrast_matrix)
+   expect_equal(attr(res_$partyid, "contrasts", exact = TRUE), party_contrast_matrix)
+
+   # Test that contrast matrices are only set for the correct explanatory
+   # variables when the model has multiple explanatory variables
+   tmp_ <- tmp_ %>%
+      dplyr::mutate(income = as.factor(income),
+                    income = `contrasts<-`(income,
+                                           value = contr.sum(length(unique(income))))
+                    )
+   income_contrast_matrix <- attr(tmp_$income_contrast_matrix, "contrasts", exact = TRUE)
+
+   res_ <- tmp_ %>%
+      specify(hours ~ partyid + income + age) %>%
+      hypothesise(null = "independence") %>%
+      generate(reps = 2, type = "permute")
+
+   expect_equal(attr(res_$partyid, "contrasts", exact = TRUE), party_contrast_matrix)
+   expect_equal(attr(res_$income, "contrasts", exact = TRUE), income_contrast_matrix)
+   expect_equal(attr(res_$age, "contrasts", exact = TRUE), NULL)
 })

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -573,3 +573,20 @@ test_that("has_p_param handles edge cases", {
    expect_false(has_p_param(set_p_names(x, c(".p.boop"))))
    expect_false(has_p_param(set_p_names(x, c("beep.boop"))))
 })
+
+test_that("Contrast matrices are preserved", {
+   # Effect-coded contrasts for a factor with 3 levels
+   tmp_ <- gss_tbl %>%
+      dplyr::mutate(partyid = as.factor(partyid),
+                    partyid = `contrasts<-`(partyid, value = contr.sum(3))
+                    )
+
+   contrast_matrix <- attr(tmp_$partyid, "contrasts", exact = TRUE)
+
+   res_ <- tmp_ %>%
+      specify(hours ~ partyid) %>%
+      hypothesise(null = "independence") %>%
+      generate(reps = 2, type = "permute")
+
+   expect_equal(attr(res_$partyid, "contrasts", exact = TRUE), contrast_matrix)
+})


### PR DESCRIPTION
This is a proposed fix for #498, which preserves any contrast matrices that the user has set on their explanatory variables by making a copy of the contrast matrices before permuting the data, and then re-attaching the contrast matrices to each variable once the permutations are finished and combined.