### PR TITLE
handle missing values when calculating confidence intervals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # infer v1.0.5.9000 (development version)
 
+* Fixed bug where `get_confidence_interval()` would error uninformatively when the supplied distribution of estimates contained missing values. The function will now warn and return a confidence interval calculated using the non-missing estimates.
+
 * Updated infrastructure for errors, warnings, and messages (#513). Most of these changes will not be visible to users, though:
      - Many longer error messages are now broken up into several lines.
      - For references to help-files, users can now click on the error message's text to navigate to the cited documentation.

--- a/tests/testthat/_snaps/get_confidence_interval.md
+++ b/tests/testthat/_snaps/get_confidence_interval.md
@@ -178,9 +178,7 @@
 # handles missing values gracefully (#520)
 
     Code
-      res <- get_confidence_interval(boot_dist)
-    Message
-      Using `level = 0.95` to compute confidence interval.
+      res <- get_confidence_interval(boot_dist, 0.95)
     Condition
       Warning:
       4 estimates were missing and were removed when calculating the confidence interval.

--- a/tests/testthat/_snaps/get_confidence_interval.md
+++ b/tests/testthat/_snaps/get_confidence_interval.md
@@ -175,3 +175,13 @@
       Error in `get_confidence_interval()`:
       ! Confidence intervals using a `z` distribution for `stat = mean` are not implemented.
 
+# handles missing values gracefully (#520)
+
+    Code
+      res <- get_confidence_interval(boot_dist)
+    Message
+      Using `level = 0.95` to compute confidence interval.
+    Condition
+      Warning:
+      4 estimates were missing and were removed when calculating the confidence interval.
+

--- a/tests/testthat/test-get_confidence_interval.R
+++ b/tests/testthat/test-get_confidence_interval.R
@@ -471,3 +471,22 @@ test_that("theoretical CIs check arguments properly", {
     )
   )
 })
+
+test_that("handles missing values gracefully (#520)", {
+   data <- data.frame(
+      prop = seq(0, 1, length.out = 10),
+      group = rep(c("a", "b"), each = 5L)
+   )
+
+   set.seed(1)
+   boot_dist <-
+     data %>%
+     specify(prop ~ group) %>%
+     hypothesize(null = "independence") %>%
+     generate(reps = 1000, type = "bootstrap") %>%
+     calculate(stat = "diff in medians", order = c("b", "a"))
+
+   expect_snapshot(res <- get_confidence_interval(boot_dist, .95))
+
+   expect_s3_class(res, "data.frame")
+})


### PR DESCRIPTION
Closes #520. :)

With this PR:

``` r
library(infer)

data <- data.frame(
   prop = seq(0, 1, length.out = 10),
   group = rep(c("a", "b"), each = 5L)
)

set.seed(1)
boot_dist <-
   data %>%
   specify(prop ~ group) %>%
   hypothesize(null = "independence") %>%
   generate(reps = 1000, type = "bootstrap") %>%
   calculate(stat = "diff in medians", order = c("b", "a"))

get_confidence_interval(boot_dist, .95)
#> Warning: 4 estimates were missing and were removed when 
#> calculating the confidence interval.
#> # A tibble: 1 × 2
#>   lower_ci upper_ci
#>      <dbl>    <dbl>
#> 1    0.278    0.889
```

<sup>Created on 2023-12-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>