### PR TITLE
transition to lifecycle for deprecations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
     ggplot2,
     glue (>= 1.3.0),
     grDevices,
+    lifecycle,
     magrittr,
     methods,
     patchwork,
@@ -67,5 +68,5 @@ Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # infer (development version)
 
+* The aliases `p_value()` and `conf_int()`, first deprecated 6 years ago, now
+  return an error (#530).
+
 # infer v1.0.6
 
 * Updated infrastructure for errors, warnings, and messages (#513). Most of these changes will not be visible to users, though:

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -17,16 +17,12 @@ NULL
 #' @export
 conf_int <- function(x, level = 0.95, type = "percentile",
   point_estimate = NULL) {
-  .Deprecated("get_confidence_interval")
-  get_confidence_interval(
-    x, level = level, type = type, point_estimate = point_estimate
-  )
+  lifecycle::deprecate_stop("0.4.0", "conf_int()", "get_confidence_interval()")
 }
 
 
 #' @rdname deprecated
 #' @export
 p_value <- function(x, obs_stat, direction) {
-  .Deprecated("get_p_value")
-  get_p_value(x = x, obs_stat = obs_stat, direction = direction)
+   lifecycle::deprecate_stop("0.4.0", "conf_int()", "get_p_value()")
 }

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -150,10 +150,10 @@ t_stat <- function(x, formula,
                    conf_int = FALSE,
                    conf_level = 0.95,
                    ...) {
-  .Deprecated(
-    new = "observe",
-    msg = c("The t_stat() wrapper has been deprecated in favor of the more " ,
-            "general observe(). Please use that function instead.")
+  lifecycle::deprecate_warn(
+    when = "1.0.0",
+    what = "t_stat()",
+    with = "observe()"
   )
 
   check_conf_level(conf_level)
@@ -298,11 +298,11 @@ chisq_test <- function(x, formula, response = NULL,
 #' @export
 chisq_stat <- function(x, formula, response = NULL,
                        explanatory = NULL, ...) {
-  .Deprecated(
-    new = "observe",
-    msg = c("The chisq_stat() wrapper has been deprecated in favor of the ",
-            "more general observe(). Please use that function instead.")
-  )
+   lifecycle::deprecate_warn(
+     when = "1.0.0",
+     what = "chisq_stat()",
+     with = "observe()"
+   )
 
   # Parse response and explanatory variables
   response    <- enquo(response)

--- a/man/figures/lifecycle-archived.svg
+++ b/man/figures/lifecycle-archived.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="112" height="20" role="img" aria-label="lifecycle: archived">
+    <title>lifecycle: archived</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="112" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="57" height="20" fill="#e05d44" />
+        <rect width="112" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="825" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="470">archived</text>
+        <text x="825" y="140" transform="scale(.1)" fill="#fff" textLength="470">archived</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-defunct.svg
+++ b/man/figures/lifecycle-defunct.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="106" height="20" role="img" aria-label="lifecycle: defunct">
+    <title>lifecycle: defunct</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="51" height="20" fill="#fe7d37" />
+        <rect width="106" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="795" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="410">defunct</text>
+        <text x="795" y="140" transform="scale(.1)" fill="#fff" textLength="410">defunct</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-deprecated.svg
+++ b/man/figures/lifecycle-deprecated.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="126" height="20" role="img" aria-label="lifecycle: deprecated">
+    <title>lifecycle: deprecated</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="126" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="71" height="20" fill="#fe7d37" />
+        <rect width="126" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="895" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">deprecated</text>
+        <text x="895" y="140" transform="scale(.1)" fill="#fff" textLength="610">deprecated</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-experimental.svg
+++ b/man/figures/lifecycle-experimental.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="lifecycle: experimental">
+    <title>lifecycle: experimental</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="138" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="83" height="20" fill="#fe7d37" />
+        <rect width="138" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="955" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="730">experimental</text>
+        <text x="955" y="140" transform="scale(.1)" fill="#fff" textLength="730">experimental</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-maturing.svg
+++ b/man/figures/lifecycle-maturing.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="lifecycle: maturing">
+    <title>lifecycle: maturing</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="116" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="61" height="20" fill="#007ec6" />
+        <rect width="116" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">maturing</text>
+        <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="510">maturing</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-questioning.svg
+++ b/man/figures/lifecycle-questioning.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="128" height="20" role="img" aria-label="lifecycle: questioning">
+    <title>lifecycle: questioning</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="128" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="73" height="20" fill="#007ec6" />
+        <rect width="128" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="905" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="630">questioning</text>
+        <text x="905" y="140" transform="scale(.1)" fill="#fff" textLength="630">questioning</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-soft-deprecated.svg
+++ b/man/figures/lifecycle-soft-deprecated.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="152" height="20" role="img" aria-label="lifecycle: soft-deprecated">
+    <title>lifecycle: soft-deprecated</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="152" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="97" height="20" fill="#007ec6" />
+        <rect width="152" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="1025" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="870">soft-deprecated</text>
+        <text x="1025" y="140" transform="scale(.1)" fill="#fff" textLength="870">soft-deprecated</text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-stable.svg
+++ b/man/figures/lifecycle-stable.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="98" height="20" role="img" aria-label="lifecycle: stable">
+    <title>lifecycle: stable</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="98" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="43" height="20" fill="#4c1" />
+        <rect width="98" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">
+      lifecycle
+    </text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">
+      lifecycle
+    </text>
+        <text aria-hidden="true" x="755" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">
+      stable
+    </text>
+        <text x="755" y="140" transform="scale(.1)" fill="#fff" textLength="330">
+      stable
+    </text>
+    </g>
+</svg>

--- a/man/figures/lifecycle-superseded.svg
+++ b/man/figures/lifecycle-superseded.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="128" height="20" role="img" aria-label="lifecycle: superseded">
+    <title>lifecycle: superseded</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="128" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="55" height="20" fill="#555" />
+        <rect x="55" width="73" height="20" fill="#007ec6" />
+        <rect width="128" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="285" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">lifecycle</text>
+        <text x="285" y="140" transform="scale(.1)" fill="#fff" textLength="450">lifecycle</text>
+        <text aria-hidden="true" x="905" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="630">superseded</text>
+        <text x="905" y="140" transform="scale(.1)" fill="#fff" textLength="630">superseded</text>
+    </g>
+</svg>

--- a/tests/testthat/_snaps/aliases.md
+++ b/tests/testthat/_snaps/aliases.md
@@ -1,20 +1,18 @@
-# old aliases produce warning
+# old aliases produce informative error
 
     Code
-      res <- gss_calc %>% p_value(obs_stat = -0.2, direction = "right") %>% dplyr::pull()
+      res <- gss_calc %>% p_value(obs_stat = -0.2, direction = "right")
     Condition
-      Warning:
-      'p_value' is deprecated.
-      Use 'get_p_value' instead.
-      See help("Deprecated")
+      Error:
+      ! `conf_int()` was deprecated in infer 0.4.0 and is now defunct.
+      i Please use `get_p_value()` instead.
 
 ---
 
     Code
       res_ <- gss_permute %>% conf_int()
     Condition
-      Warning:
-      'conf_int' is deprecated.
-      Use 'get_confidence_interval' instead.
-      See help("Deprecated")
+      Error:
+      ! `conf_int()` was deprecated in infer 0.4.0 and is now defunct.
+      i Please use `get_confidence_interval()` instead.
 

--- a/tests/testthat/_snaps/observe.md
+++ b/tests/testthat/_snaps/observe.md
@@ -4,7 +4,8 @@
       res_wrap <- gss_tbl %>% chisq_stat(college ~ partyid)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -12,5 +13,6 @@
       res_wrap_2 <- gss_tbl %>% t_stat(hours ~ sex, order = c("male", "female"))
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 

--- a/tests/testthat/_snaps/wrappers.md
+++ b/tests/testthat/_snaps/wrappers.md
@@ -36,7 +36,8 @@
       res_ <- gss_tbl %>% chisq_stat(college ~ partyid)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -44,7 +45,8 @@
       obs_stat_way <- gss_tbl %>% chisq_stat(college ~ partyid)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -52,7 +54,8 @@
       obs_stat_way <- gss_tbl %>% chisq_stat(partyid ~ NULL)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -60,7 +63,8 @@
       obs_stat_way_alt <- gss_tbl %>% chisq_stat(response = partyid)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -68,7 +72,8 @@
       res_ <- gss_tbl %>% t_stat(hours ~ sex, order = c("male", "female"))
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -76,7 +81,8 @@
       obs_stat_way <- gss_tbl %>% t_stat(hours ~ sex, order = c("male", "female"))
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -85,7 +91,8 @@
         order = c("male", "female"))
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -93,7 +100,8 @@
       res_ <- gss_tbl %>% t_stat(hours ~ NULL)
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -101,7 +109,8 @@
       obs_stat_way <- gss_tbl %>% t_stat(hours ~ NULL)
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -109,7 +118,8 @@
       obs_stat_way_alt <- gss_tbl %>% t_stat(response = hours)
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -117,7 +127,8 @@
       res_ <- chisq_stat(x = gss_tbl, response = age, explanatory = sex)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
       Error in `chisq_stat()`:
       ! The response variable of `age` is not appropriate since the response variable is expected to be categorical.
 
@@ -127,7 +138,8 @@
       res_ <- chisq_stat(x = gss_tbl, response = sex, explanatory = age)
     Condition
       Warning:
-      The chisq_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `chisq_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
       Error in `chisq_stat()`:
       ! The explanatory variable of `age` is not appropriate since the response variable is expected to be categorical.
 
@@ -147,7 +159,8 @@
         "male"))
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 ---
 
@@ -156,7 +169,8 @@
       var.equal = TRUE)
     Condition
       Warning:
-      The t_stat() wrapper has been deprecated in favor of the more general observe(). Please use that function instead.
+      `t_stat()` was deprecated in infer 1.0.0.
+      i Please use `observe()` instead.
 
 # two sample prop_test works
 

--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -10,14 +10,15 @@ test_that("aliases work", {
   expect_silent(gss_permute %>% get_ci())
 })
 
-test_that("old aliases produce warning", {
+test_that("old aliases produce informative error", {
   expect_snapshot(
+    error = TRUE,
     res <- gss_calc %>%
-      p_value(obs_stat = -0.2, direction = "right") %>%
-      dplyr::pull()
+      p_value(obs_stat = -0.2, direction = "right")
   )
 
-  expect_equal(res, 1)
-
-  expect_snapshot(res_ <- gss_permute %>% conf_int())
+  expect_snapshot(
+     error = TRUE,
+     res_ <- gss_permute %>% conf_int()
+    )
 })


### PR DESCRIPTION
Closes #530. Transitions deprecations from `.Deprecated()` to `lifecycle::deprecate_warn()` and advances the deprecations for `p_value()` and `conf_int()` to `lifecycle::deprecate_stop()`. 