### PR TITLE
truncate variable descriptions that are wider than the console

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # infer (development version)
 
+* The infer print method now truncates output when descriptions of explanatory 
+  or responses variables exceed the console width (#543).
+
 * Added missing commas and addressed formatting issues throughout the vignettes and articles. Backticks for package names were removed and missing parentheses for functions were added (@Joscelinrocha).
 
 # infer 1.0.7

--- a/R/print_methods.R
+++ b/R/print_methods.R
@@ -28,7 +28,11 @@ print.infer <- function(x, ...) {
     header[3] <- glue('Null Hypothesis: {attr(x, "null")}', .null = "NULL")
   }
 
-  cat(glue::glue_collapse(header[header != ""], sep = "\n"))
+  cat(glue::glue_collapse(
+    header[header != ""],
+    width = cli::console_width(),
+    sep = "\n"
+  ))
   cat("\n")
 
   NextMethod()

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -1,0 +1,22 @@
+# print method fits linewidth with many predictors (#543)
+
+    Code
+      specify(mtcars, mpg ~ cyl + disp + hp + drat + wt + qsec)
+    Output
+      Response: mpg (numeric)
+      Explanatory: cyl (numeric), disp (numeric), hp (numer...
+      # A tibble: 32 x 7
+           mpg   cyl  disp    hp  drat    wt  qsec
+         <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+       1  21       6  160    110  3.9   2.62  16.5
+       2  21       6  160    110  3.9   2.88  17.0
+       3  22.8     4  108     93  3.85  2.32  18.6
+       4  21.4     6  258    110  3.08  3.22  19.4
+       5  18.7     8  360    175  3.15  3.44  17.0
+       6  18.1     6  225    105  2.76  3.46  20.2
+       7  14.3     8  360    245  3.21  3.57  15.8
+       8  24.4     4  147.    62  3.69  3.19  20  
+       9  22.8     4  141.    95  3.92  3.15  22.9
+      10  19.2     6  168.   123  3.92  3.44  18.3
+      # i 22 more rows
+

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -6,3 +6,7 @@ test_that("print works", {
       generate(reps = 10, type = "permute")
   ))
 })
+
+test_that("print method fits linewidth with many predictors (#543)", {
+  expect_snapshot(specify(mtcars, mpg ~ cyl + disp + hp + drat + wt + qsec))
+})


### PR DESCRIPTION
Closes #543. Takes the tibble-esque approach of just truncating the variable descriptions and then ending with ellipses rather than "wrapping" the whole description to the console width, though I'm game to do the latter if we feel that's a better approach.