### PR TITLE
address `fit.infer()` + `visualize()` snap failures

### DIFF
--- a/tests/testthat/_snaps/visualize/viz-fit-bare.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-bare.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='33.38' y='28.26' width='675.66' height='146.21' />
   </clipPath>
@@ -101,16 +121,6 @@
 <text x='631.74' y='185.46' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.10</text>
 <text x='371.21' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>age</text>
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
@@ -176,16 +186,6 @@
 <text x='641.97' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='371.21' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/_snaps/visualize/viz-fit-conf-int.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-conf-int.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='33.38' y='28.26' width='675.66' height='146.21' />
   </clipPath>
@@ -104,16 +124,6 @@
 <text x='631.74' y='185.46' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.10</text>
 <text x='371.21' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>age</text>
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
@@ -182,16 +192,6 @@
 <text x='641.97' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='371.21' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/_snaps/visualize/viz-fit-no-h0.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-no-h0.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpNDAuNzJ8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='40.72' y='28.26' width='668.32' height='146.21' />
   </clipPath>
@@ -105,16 +125,6 @@
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
 </g>
 <defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-</g>
-<defs>
   <clipPath id='cpNDAuNzJ8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
     <rect x='40.72' y='210.84' width='668.32' height='146.21' />
   </clipPath>
@@ -171,16 +181,6 @@
 <text x='645.00' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='374.88' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpNDAuNzJ8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/_snaps/visualize/viz-fit-p-val-both.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-p-val-both.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='33.38' y='28.26' width='675.66' height='146.21' />
   </clipPath>
@@ -106,16 +126,6 @@
 <text x='631.74' y='185.46' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.10</text>
 <text x='371.21' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>age</text>
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
@@ -185,16 +195,6 @@
 <text x='604.62' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='371.21' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/_snaps/visualize/viz-fit-p-val-left.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-p-val-left.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='33.38' y='28.26' width='675.66' height='146.21' />
   </clipPath>
@@ -104,16 +124,6 @@
 <text x='631.74' y='185.46' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.10</text>
 <text x='371.21' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>age</text>
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
@@ -183,16 +193,6 @@
 <text x='604.61' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='371.21' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/_snaps/visualize/viz-fit-p-val-right.svg
+++ b/tests/testthat/_snaps/visualize/viz-fit-p-val-right.svg
@@ -40,6 +40,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDI4LjI2fDE3NC40Nw=='>
     <rect x='33.38' y='28.26' width='675.66' height='146.21' />
   </clipPath>
@@ -104,16 +124,6 @@
 <text x='631.74' y='185.46' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.10</text>
 <text x='371.21' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>age</text>
 <text transform='translate(18.53,101.37) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
-    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
-<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDIxMC44NHwzNTcuMDU='>
@@ -181,16 +191,6 @@
 <text x='604.61' y='368.04' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='371.21' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>collegedegree</text>
 <text transform='translate(18.53,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
-    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
-<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuMzh8NzA5LjA0fDM5My40Mnw1MzkuNjM='>

--- a/tests/testthat/test-visualize.R
+++ b/tests/testthat/test-visualize.R
@@ -623,6 +623,7 @@ test_that("visualize warns about removing `NaN`", {
 
 test_that("visualize can handle multiple explanatory variables", {
   skip_if(getRversion() < "4.1.0")
+  skip_if_not(identical(Sys.info()[["sysname"]], "Darwin"))
 
   # generate example objects
   null_fits <- gss %>%


### PR DESCRIPTION
Seeing snap failures for `visualize()` on `fit.infer()` output (first seen in #544 but can also observe on `main`)—only tests on output from `fit()`, and _all_ of the output from `fit()`. No changes to vdiffr or the graphics engine that would explain the new failures, and only on macOS, so I'm a bit confused as to what the root cause may be, but the snaps are visually indistinguishable to me.

I'm guessing macOS will pass but other check systems will fail, in which case we'll need to make snap variants depending on OS.