### PR TITLE
transition from deprecated ggplot2 function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     cli,
     dplyr (>= 0.7.0),
     generics,
-    ggplot2,
+    ggplot2 (>= 3.5.2),
     glue (>= 1.3.0),
     grDevices,
     lifecycle,

--- a/R/visualize.R
+++ b/R/visualize.R
@@ -328,7 +328,7 @@ check_visualize_args <- function(data, bins, method, dens_color, call = caller_e
 # to visualize()d objects to make sure they weren't mistakenly piped
 check_for_piped_visualize <- function(..., call = caller_env()) {
 
-  is_ggplot_output <- vapply(list(...), ggplot2::is.ggplot, logical(1))
+  is_ggplot_output <- vapply(list(...), ggplot2::is_ggplot, logical(1))
 
   if (any(is_ggplot_output)) {
 


### PR DESCRIPTION
ggplot2 3.5.2 just now made it to CRAN—may take a day or two for the runners to have the newest version.